### PR TITLE
feat(mysql-test): ASAN perl suppressions for gcc/clang

### DIFF
--- a/mysql-test/asan.supp
+++ b/mysql-test/asan.supp
@@ -21,3 +21,16 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
 
 # ASAN suppressions for gcc/clang
+#example:
+#interceptor_via_fun:NameOfCFunctionToSuppress
+#interceptor_via_fun:-[ClassName objCMethodToSuppress:]
+#interceptor_via_lib:NameOfTheLibraryToSuppress
+
+interceptor_via_fun:Perl_safesyscalloc
+interceptor_via_fun:Perl_safesysmalloc
+interceptor_via_fun:Perl_more_bodies
+interceptor_via_fun:Perl_init_stacks
+interceptor_via_fun::Perl_reentrant_init
+interceptor_via_fun:Perl_safesysmalloc
+interceptor_via_fun:Perl_new_stackinfo
+interceptor_via_fun:perl_construct

--- a/mysql-test/lsan.supp
+++ b/mysql-test/lsan.supp
@@ -29,6 +29,13 @@ leak:Perl_Slab_Alloc
 leak:Perl_newUNOP_AUX
 leak:Perl_newSTATEOP
 leak:Perl_pmruntime
+#for higher version
+leak:Perl_more_bodies
+leak:Perl_init_stacks
+leak:Perl_reentrant_init
+leak:Perl_safesysmalloc
+leak:Perl_new_stackinfo
+leak:perl_construct
 leak:/usr/bin/perl
 leak:/usr/bin/sort
 leak:/usr/bin/tail


### PR DESCRIPTION
perl version higher than 5.30.x, will gen incorrect leakage error msg.