### PR TITLE
fix(rapid): fixup some mysql type selection and warnings

### DIFF
--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -2732,9 +2732,9 @@ static bool secondary_engine_load_table(THD *thd, const TABLE &table) {
     row_rpd_columns.table_id = static_cast<uint>(table.s->table_map_id.id());
     row_rpd_columns.column_id = field_ptr->field_index();
     strncpy(row_rpd_columns.column_name, field_ptr->field_name,
-            strlen(field_ptr->field_name));
+            strlen(row_rpd_columns.column_name));
     strncpy(row_rpd_columns.table_name, table.s->table_name.str,
-            strlen(table.s->table_name.str));
+            strlen(row_rpd_columns.table_name));
     row_rpd_columns.data_dict_bytes = 0;
     row_rpd_columns.data_placement_index = 0;
 

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -8232,10 +8232,12 @@ static mysql_row_templ_t *build_template_field(
 
   if (!templ->is_virtual) {
     templ->col_no = i;
+
+    auto trx_id_ind = clust_index->table->get_sys_col(DATA_TRX_ID)->get_col_phy_pos();
     templ->clust_rec_field_no = (field->type() != MYSQL_TYPE_DB_TRX_ID)?
                                 dict_col_get_clust_pos(col, clust_index) :
-                                (clust_index->n_user_defined_cols ?
-                                 clust_index->n_user_defined_cols : 1);
+                                trx_id_ind;
+
     ut_a(templ->clust_rec_field_no != ULINT_UNDEFINED);
 
     if (index->is_clustered()) {

--- a/storage/innobase/include/row0sel.h
+++ b/storage/innobase/include/row0sel.h
@@ -440,15 +440,15 @@ mysql_col_len, mbminlen, mbmaxlen
                                 range comparison. */
 void row_sel_field_store_in_mysql_format_func(
     byte *dest, const mysql_row_templ_t *templ, const dict_index_t *index,
-    IF_DEBUG(ulint field_no, ) const byte *data,
-    ulint len IF_DEBUG(, ulint sec_field));
+    ulint field_no, const byte *data,
+    ulint len , ulint sec_field);
 
 /** Convert a non-SQL-NULL field from Innobase format to MySQL format. */
 static inline void row_sel_field_store_in_mysql_format(
     byte *dest, const mysql_row_templ_t *templ, const dict_index_t *idx,
     ulint field, const byte *src, ulint len, ulint sec) {
   row_sel_field_store_in_mysql_format_func(
-      dest, templ, idx, IF_DEBUG(field, ) src, len IF_DEBUG(, sec));
+      dest, templ, idx, field,  src, len , sec);
 }
 
 /** Search the record present in innodb_table_stats table using

--- a/storage/innobase/row/row0sel.cc
+++ b/storage/innobase/row/row0sel.cc
@@ -2500,8 +2500,8 @@ mysql_col_len, mbminlen, mbmaxlen
                                 range comparison. */
 void row_sel_field_store_in_mysql_format_func(
     byte *dest, const mysql_row_templ_t *templ, const dict_index_t *index,
-    IF_DEBUG(ulint field_no, ) const byte *data,
-    ulint len IF_DEBUG(, ulint sec_field)) {
+    ulint field_no,  const byte *data,
+    ulint len , ulint sec_field) {
   byte *ptr;
 //#ifdef UNIV_DEBUG
   const dict_field_t *field =
@@ -2511,7 +2511,7 @@ void row_sel_field_store_in_mysql_format_func(
   prtype = (templ->type != DATA_SYS && field) ? field->col->prtype : DATA_TRX_ID;
   ib_id_t id;
 
-  bool clust_templ_for_sec = (sec_field != ULINT_UNDEFINED);
+  bool clust_templ_for_sec [[maybe_unused]] = (sec_field != ULINT_UNDEFINED);
 //#endif /* UNIV_DEBUG */
   ulint mysql_col_len =
       templ->is_multi_val ? templ->mysql_mvidx_len : templ->mysql_col_len;
@@ -2663,8 +2663,7 @@ void row_sel_field_store_in_mysql_format_func(
         memset(dest + len, 0x20, mysql_col_len - len);
       }
       break;
-
-    default:
+   
     case DATA_SYS_CHILD:
     case DATA_SYS:
       /* These column types should never be shipped to MySQL. But, in Shannon,
@@ -2680,6 +2679,7 @@ void row_sel_field_store_in_mysql_format_func(
            break;
       }
       break;
+    default:
 #ifdef UNIV_DEBUG
     case DATA_CHAR:
     case DATA_FIXBINARY:
@@ -2997,8 +2997,9 @@ bool row_sel_store_mysql_rec(byte *mysql_rec, row_prebuilt_t *prebuilt,
     /* We should never deliver column prefixes to MySQL,
     except for evaluating innobase_index_cond() or
     row_search_end_range_check(). */
-    if (templ->type != DATA_SYS)
+    if (templ->type != DATA_SYS){
       ut_ad(rec_index->get_field(field_no)->prefix_len == 0);
+    }
 
     if (clust_templ_for_sec) {
       std::vector<const dict_col_t *>::iterator it;

--- a/storage/perfschema/table_rpd_column_id.cc
+++ b/storage/perfschema/table_rpd_column_id.cc
@@ -138,7 +138,7 @@ int table_rpd_column_id::make_row(uint index[[maybe_unused]]) {
     m_row.column_id = ShannonBase::meta_rpd_columns_infos[index].column_id;
     m_row.table_id = ShannonBase::meta_rpd_columns_infos[index].table_id;
     strncpy(m_row.column_name, ShannonBase::meta_rpd_columns_infos[index].column_name,
-            strlen(ShannonBase::meta_rpd_columns_infos[index].column_name));
+            strlen(m_row.column_name));
     m_row.column_name_length = strlen(ShannonBase::meta_rpd_columns_infos[index].column_name);
   }
   return 0;

--- a/storage/perfschema/table_rpd_columns.cc
+++ b/storage/perfschema/table_rpd_columns.cc
@@ -149,7 +149,7 @@ int table_rpd_columns::make_row(uint index[[maybe_unused]]) {
     m_row.ndv = ShannonBase::meta_rpd_columns_infos[index].ndv;
     memset(m_row.encoding, 0x0, NAME_LEN);
     strncpy(m_row.encoding, ShannonBase::meta_rpd_columns_infos[index].encoding,
-            strlen(ShannonBase::meta_rpd_columns_infos[index].encoding));
+            strlen(m_row.encoding));
   }
   return 0;
 }


### PR DESCRIPTION
1: fixup some mysql types return wrong result in release mode.
2: remove some compilation warnings in release mode.
3: refine way getting index of `db_trx_id`.