### PR TITLE
feat(shannon): partii : to support partition table in rapid

### DIFF
--- a/mysql-test/suite/secondary_engine/r/shannon_partition_table.result
+++ b/mysql-test/suite/secondary_engine/r/shannon_partition_table.result
@@ -1,6 +1,6 @@
-create database tpch_1024;
-alter database tpch_1024 CHARACTER SET ascii COLLATE ascii_bin;
-use tpch_1024;
+create database test_partition;
+alter database test_partition CHARACTER SET ascii COLLATE ascii_bin;
+use test_partition;
 CREATE TABLE LINEITEM ( L_ORDERKEY    BIGINT NOT NULL,
 L_PARTKEY     INTEGER NOT NULL,
 L_SUPPKEY     INTEGER NOT NULL,
@@ -46,22 +46,12 @@ L_ORDERKEY	L_PARTKEY	L_SUPPKEY	L_LINENUMBER	L_QUANTITY	L_EXTENDEDPRICE	L_DISCOUN
 24000000	712607	2625	4	7.00	11336.99	0.09	0.00	N	O	1996-07-16	1996-06-18	1996-08-04	COLLECT COD	SHIP	ckly express requests. even, pendin
 24000000	651246	21263	1	5.00	5986.05	0.06	0.05	N	O	1996-06-11	1996-05-16	1996-06-22	NONE	TRUCK	nts use. ir
 alter table LINEITEM secondary_unload;
-alter table LINEITEM secondary_load;
-explain select * from LINEITEM;
-id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	LINEITEM	p0,p1,p2,p3,p4,p5,p6,p7,p8,p9,p10,p11,p12,p13,p14,p15,p16,p17,p18,p19,p20,p21,p22,p23,p24,p25,p26,p27,p28,p29,p30,p31,p32,p33,p34,p35,p36,p37,p38,p39,p40,p41,p42,p43,p44,p45,p46,p47,p48,p49,p50,p51,p52,p53,p54,p55,p56,p57,p58,p59,p60,p61,p62,p63,p64,p65,p66,p67,p68,p69,p70,p71,p72,p73,p74,p75,p76,p77,p78,p79,p80,p81,p82,p83,p84,p85,p86,p87,p88,p89,p90,p91,p92,p93,p94,p95,p96,p97,p98,p99,p100,p101,p102,p103,p104,p105,p106,p107,p108,p109,p110,p111,p112,p113,p114,p115,p116,p117,p118,p119,p120,p121,p122,p123,p124,p125,p126,p127	ALL	NULL	NULL	NULL	NULL	10	100.00	Using secondary engine Rapid
-select * from LINEITEM;
-L_ORDERKEY	L_PARTKEY	L_SUPPKEY	L_LINENUMBER	L_QUANTITY	L_EXTENDEDPRICE	L_DISCOUNT	L_TAX	L_RETURNFLAG	L_LINESTATUS	L_SHIPDATE	L_COMMITDATE	L_RECEIPTDATE	L_SHIPINSTRUCT	L_SHIPMODE	L_COMMENT
-23999975	625094	15140	2	23.00	23438.38	0.05	0.06	N	O	1996-10-23	1996-09-11	1996-11-12	DELIVER IN PERSON	AIR	ly regular realms after the
-24000000	677354	17387	2	30.00	39939.60	0.00	0.01	N	O	1996-04-21	1996-06-08	1996-05-08	TAKE BACK RETURN	REG AIR	le? blithely unusual deposits above
-23999975	350648	30649	3	18.00	30575.34	0.08	0.01	N	O	1996-10-07	1996-08-22	1996-10-19	DELIVER IN PERSON	TRUCK	ully pending dependencies hagg
-23999974	737406	7461	5	2.00	2886.74	0.03	0.07	N	O	1997-04-25	1997-05-31	1997-05-21	NONE	REG AIR	nding accounts. ironic, final
-23999974	770178	30217	6	48.00	59910.72	0.02	0.08	N	O	1997-03-15	1997-05-26	1997-03-26	TAKE BACK RETURN	FOB	fy packages nag evenly
-24000000	277642	37643	3	20.00	32392.60	0.01	0.02	N	O	1996-05-14	1996-06-11	1996-06-04	TAKE BACK RETURN	REG AIR	s. blithely regular instructi
-23999975	353843	3852	1	1.00	1896.83	0.05	0.01	N	O	1996-08-03	1996-09-14	1996-08-15	TAKE BACK RETURN	RAIL	pending instructions affix qu
-23999974	311819	31820	4	22.00	40277.60	0.08	0.01	N	O	1997-03-25	1997-04-24	1997-03-28	COLLECT COD	REG AIR	uickly ironic pains. bli
-24000000	712607	2625	4	7.00	11336.99	0.09	0.00	N	O	1996-07-16	1996-06-18	1996-08-04	COLLECT COD	SHIP	ckly express requests. even, pendin
-24000000	651246	21263	1	5.00	5986.05	0.06	0.05	N	O	1996-06-11	1996-05-16	1996-06-22	NONE	TRUCK	nts use. ir
+alter table LINEITEM secondary_load PARTITION(p0, p1, p10);
+alter table LINEITEM secondary_unload;
+alter table LINEITEM secondary_load PARTITION(p0, p1, p10);
+alter table LINEITEM secondary_unload PARTITION(p0, p10, p1);
+alter table LINEITEM secondary_load PARTITION(p0, p1, p10);
+alter table LINEITEM secondary_unload PARTITION(p0, p10);
 alter table LINEITEM secondary_unload;
 SET SESSION optimizer_switch='hypergraph_optimizer=on';
 Warnings:
@@ -71,4 +61,4 @@ set secondary_engine_cost_threshold =1.5;
 set rapid_use_dynamic_offload=1;
 SET optimizer_trace = 'enabled=on';
 SET SESSION optimizer_switch='hypergraph_optimizer=on';
-drop database tpch_1024;
+drop database test_partition;

--- a/mysql-test/suite/secondary_engine/t/shannon_partition_table.test
+++ b/mysql-test/suite/secondary_engine/t/shannon_partition_table.test
@@ -4,9 +4,9 @@
 ##############################################################################
 
 --disable_warnings
-create database tpch_1024;
-alter database tpch_1024 CHARACTER SET ascii COLLATE ascii_bin; 
-use tpch_1024;
+create database test_partition;
+alter database test_partition CHARACTER SET ascii COLLATE ascii_bin; 
+use test_partition;
 
 CREATE TABLE LINEITEM ( L_ORDERKEY    BIGINT NOT NULL,
                         L_PARTKEY     INTEGER NOT NULL,
@@ -53,9 +53,14 @@ explain select * from LINEITEM;
 select * from LINEITEM;
 alter table LINEITEM secondary_unload;
 
-alter table LINEITEM secondary_load;
-explain select * from LINEITEM;
-select * from LINEITEM;
+alter table LINEITEM secondary_load PARTITION(p0, p1, p10);
+alter table LINEITEM secondary_unload;
+
+alter table LINEITEM secondary_load PARTITION(p0, p1, p10);
+alter table LINEITEM secondary_unload PARTITION(p0, p10, p1);
+
+alter table LINEITEM secondary_load PARTITION(p0, p1, p10);
+alter table LINEITEM secondary_unload PARTITION(p0, p10);
 alter table LINEITEM secondary_unload;
 --enable_warnings
 
@@ -67,4 +72,4 @@ set rapid_use_dynamic_offload=1;
 SET optimizer_trace = 'enabled=on';
 SET SESSION optimizer_switch='hypergraph_optimizer=on';
 
-drop database tpch_1024;
+drop database test_partition;

--- a/storage/rapid_engine/imcs/cu.cpp
+++ b/storage/rapid_engine/imcs/cu.cpp
@@ -93,6 +93,8 @@ Cu::Cu(const Field *field) {
       .append(field->field_name);
 }
 
+Cu::Cu(const Field *field, std::string &name) : Cu(field) { m_cu_key = name; }
+
 Cu::~Cu() {
   if (m_chunks.size()) m_chunks.clear();
 }

--- a/storage/rapid_engine/imcs/cu.h
+++ b/storage/rapid_engine/imcs/cu.h
@@ -92,6 +92,7 @@ class Cu : public MemoryObject {
   };
 
   explicit Cu(const Field *field);
+  Cu(const Field *field, std::string &name);
   virtual ~Cu();
   Cu(Cu &&) = delete;
   Cu &operator=(Cu &&) = delete;

--- a/storage/rapid_engine/imcs/data_table.cpp
+++ b/storage/rapid_engine/imcs/data_table.cpp
@@ -82,9 +82,13 @@ DataTable::DataTable(TABLE *source_table) : m_initialized{false}, m_data_source(
         key.clear();
       }
     } else {
-      key.append(key_part).append(fld->field_name);
-      m_field_cus.emplace_back(Imcs::instance()->get_cu(key));
-      key.clear();
+      std::shared_lock<std::shared_mutex> lk(Imcs::instance()->get_cu_mutex());
+      const auto &cus = Imcs::instance()->get_cus();
+      std::for_each(cus.begin(), cus.end(), [&](const auto &cu) {
+        if (cu.first.find(key_part) != std::string::npos && cu.first.rfind(fld->field_name) != std::string::npos) {
+          m_field_cus.emplace_back(cu.second.get());
+        }
+      });
     }
   }
 

--- a/storage/rapid_engine/imcs/purge/purge.cpp
+++ b/storage/rapid_engine/imcs/purge/purge.cpp
@@ -104,8 +104,8 @@ static void purge_func_main() {
     thread_num = std::min(thread_num, loaded_cu_sz);
 
     size_t thr_cnt = 0;
+    std::shared_lock<std::shared_mutex> lk_cu(ShannonBase::Imcs::Imcs::instance()->get_cu_mutex());
     for (auto &cu : ShannonBase::Imcs::Imcs::instance()->get_cus()) {
-      std::scoped_lock lk(cu.second.get()->get_mutex());
       results.emplace_back(std::async(std::launch::async, purger_purge_worker, cu.second.get()));
       thr_cnt++;
 


### PR DESCRIPTION
this is part ii of to support partition table in rapid engine. in this part, to support unload partition table, such as 'alter table xxx secondary_unload partition(p1, p2, ..., pN)'.

I hereby agree to the terms of the CLA available at: http://www.shannondata.ai/doc/cla/

## Summary

_to support partion table in rapid._

- Fixes #392 
## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):