### PR TITLE
fix(cmake): Compatible with multiple languages including English for CPU vendor detection #446

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -782,7 +782,7 @@ elseif (APPLE)
 elseif (UNIX AND NOT APPLE)
     execute_process(
         COMMAND lscpu
-        COMMAND grep "Vendor ID"
+        COMMAND grep "ID"
         OUTPUT_VARIABLE CPU_MANUFACTURER
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: http://www.shannondata.ai/doc/cla/

## Summary

_Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR._

- Fixes #[#446]
- 
CMake Error: "Unsupported CPU manufacturer"

reason:
If cpuinfo used languages like ZH-CN "厂商 ID：                 AuthenticAMD"
COMMAND： grep "Vendor ID" will return nothing

fixed: grep "Vendor ID" --> grep "ID"

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):