### PR TITLE
feat(hotfix): fixup the null-bility check in batch read

### DIFF
--- a/mysql-test/suite/secondary_engine/r/shannon_vector_iterators.result
+++ b/mysql-test/suite/secondary_engine/r/shannon_vector_iterators.result
@@ -19,7 +19,7 @@ INSERT INTO t_rapid VALUES
 (6,600),(7,700),(8,800),(9,900),(10,1000);
 SET USE_SECONDARY_ENGINE = OFF;
 EXPLAIN FORMAT=TREE
-SELECT t_innodb.id, t_innodb.val, t_rapid.val
+SELECT /*+ HASH_JOIN(t_rapid) */ t_innodb.id, t_innodb.val, t_rapid.val
 FROM t_innodb
 JOIN t_rapid
 ON t_innodb.id = t_rapid.id
@@ -32,7 +32,7 @@ EXPLAIN
             -> Hash
                 -> Table scan on t_innodb  (cost=X rows=X)
 
-SELECT t_innodb.id, t_innodb.val, t_rapid.val 
+SELECT /*+ HASH_JOIN(t_rapid) */ t_innodb.id, t_innodb.val, t_rapid.val 
 FROM t_innodb 
 JOIN t_rapid   
 ON t_innodb.id = t_rapid.id 
@@ -48,8 +48,9 @@ ALTER TABLE t_rapid SECONDARY_LOAD;
 SET USE_SECONDARY_ENGINE = ON;
 SET rapid_use_dynamic_offload=off;
 SET secondary_engine_cost_threshold=10;
+SET SESSION optimizer_switch = 'hash_join=off';
 EXPLAIN FORMAT=TREE
-SELECT t_innodb.id, t_innodb.val, t_rapid.val
+SELECT  /*+ NO_HASH_JOIN(t_rapid) */ t_innodb.id, t_innodb.val, t_rapid.val
 FROM t_innodb
 JOIN t_rapid
 ON t_innodb.id = t_rapid.id
@@ -61,7 +62,7 @@ EXPLAIN
             -> Table scan on t_rapid  (cost=X rows=X)
             -> Single-row index lookup on t_innodb using PRIMARY (id=t_rapid.id)  (cost=X rows=X)
 
-SELECT t_innodb.id, t_innodb.val, t_rapid.val 
+SELECT  /*+ NO_HASH_JOIN(t_rapid) */ t_innodb.id, t_innodb.val, t_rapid.val 
 FROM t_innodb 
 JOIN t_rapid   
 ON t_innodb.id = t_rapid.id 
@@ -72,6 +73,7 @@ id	val	val
 3	30	300
 4	40	400
 5	50	500
+SET SESSION optimizer_switch = 'hash_join=on';
 SET USE_SECONDARY_ENGINE = ON;
 CREATE TABLE customers (
 customer_id INT PRIMARY KEY AUTO_INCREMENT,

--- a/mysql-test/suite/secondary_engine/t/shannon_vector_iterators.test
+++ b/mysql-test/suite/secondary_engine/t/shannon_vector_iterators.test
@@ -32,13 +32,13 @@ INSERT INTO t_rapid VALUES
 SET USE_SECONDARY_ENGINE = OFF;
 --replace_regex /\(cost=[0-9.]+/\(cost=X/ /rows=[0-9]+/rows=X/ /\(rows=[0-9]+\)/\(rows=X\)/
 EXPLAIN FORMAT=TREE
-SELECT t_innodb.id, t_innodb.val, t_rapid.val
+SELECT /*+ HASH_JOIN(t_rapid) */ t_innodb.id, t_innodb.val, t_rapid.val
 FROM t_innodb
 JOIN t_rapid
   ON t_innodb.id = t_rapid.id
 ORDER BY t_innodb.id;
 
-SELECT t_innodb.id, t_innodb.val, t_rapid.val 
+SELECT /*+ HASH_JOIN(t_rapid) */ t_innodb.id, t_innodb.val, t_rapid.val 
 FROM t_innodb 
 JOIN t_rapid   
   ON t_innodb.id = t_rapid.id 
@@ -51,22 +51,24 @@ SET USE_SECONDARY_ENGINE = ON;
 SET rapid_use_dynamic_offload=off;
 SET secondary_engine_cost_threshold=10;
 
+SET SESSION optimizer_switch = 'hash_join=off';
 ########### it will use vectorized table scan, rapid_table::index_read. nest loop join. ###########
 --replace_regex /\(cost=[0-9.]+/\(cost=X/ /rows=[0-9]+/rows=X/ /\(rows=[0-9]+\)/\(rows=X\)/
 EXPLAIN FORMAT=TREE
-SELECT t_innodb.id, t_innodb.val, t_rapid.val
+SELECT  /*+ NO_HASH_JOIN(t_rapid) */ t_innodb.id, t_innodb.val, t_rapid.val
 FROM t_innodb
 JOIN t_rapid
   ON t_innodb.id = t_rapid.id
 ORDER BY t_innodb.id;
 
-SELECT t_innodb.id, t_innodb.val, t_rapid.val 
+SELECT  /*+ NO_HASH_JOIN(t_rapid) */ t_innodb.id, t_innodb.val, t_rapid.val 
 FROM t_innodb 
 JOIN t_rapid   
   ON t_innodb.id = t_rapid.id 
 ORDER BY t_innodb.id;
 
 #########################Vectorized JOIN/Aggregation #######################
+SET SESSION optimizer_switch = 'hash_join=on';
 SET USE_SECONDARY_ENGINE = ON;
 CREATE TABLE customers (
     customer_id INT PRIMARY KEY AUTO_INCREMENT,

--- a/storage/rapid_engine/trx/readview.h
+++ b/storage/rapid_engine/trx/readview.h
@@ -44,7 +44,8 @@ namespace ReadView {
 
 // Bit mask, used for visibile row count.
 struct BitmapResult {
-  std::vector<uint8_t> bitmask;  // bit i => row_start + ith visibility: 1 visible, 0 invisible
+  std::vector<uint8_t> bitmask;       // bit i => row_start + ith visibility: 1 visible, 0 invisible
+  std::vector<uint8_t> null_bitmask;  // NULL bitmap, if it is visiable, then check this for null or not.
   size_t visible_count{0};
 };
 


### PR DESCRIPTION
We use column-based version-link, each column has its own SMU. The null and visiblity of each are different. Therefore, we can not use one SMU to check the other visiblity and null-bility of other column.

Fixes: #542

I hereby agree to the terms of the CLA available at: http://www.shannondata.ai/doc/cla/

## Summary

_We use column-based version-link, each column has its own SMU. The null and visiblity of each are different. Therefore, we can not use one SMU to check the other visiblity and null-bility of other column.._

- Fixes #542

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):