### PR TITLE
feat(shannon):fix count(*) in rapid engine

### DIFF
--- a/mysql-test/suite/secondary_engine/r/shannon_vector_iterators.result
+++ b/mysql-test/suite/secondary_engine/r/shannon_vector_iterators.result
@@ -98,6 +98,13 @@ Japan	11	158	12468	189918	86148.29
 SET USE_SECONDARY_ENGINE=ON;
 SET secondary_engine_cost_threshold=0;
 SET rapid_use_dynamic_offload=off;
+EXPLAIN FORMAT=TREE SELECT COUNT(*) FROM customers;
+EXPLAIN
+-> Count rows in customers
+
+SELECT COUNT(*) FROM customers;
+COUNT(*)
+1000
 SELECT 
 c.country,
 COUNT(DISTINCT c.customer_id),

--- a/mysql-test/suite/secondary_engine/t/shannon_vector_iterators.test
+++ b/mysql-test/suite/secondary_engine/t/shannon_vector_iterators.test
@@ -85,6 +85,9 @@ SET USE_SECONDARY_ENGINE=ON;
 SET secondary_engine_cost_threshold=0;
 SET rapid_use_dynamic_offload=off;
 
+EXPLAIN FORMAT=TREE SELECT COUNT(*) FROM customers;
+SELECT COUNT(*) FROM customers;
+
 #--replace_regex /\(cost=[0-9.]+/\(cost=X/ /rows=[0-9]+/rows=X/ /\(rows=[0-9]+\)/\(rows=X\)/
 #explain SELECT 
 #    c.country,

--- a/storage/rapid_engine/handler/ha_shannon_rapid.cc
+++ b/storage/rapid_engine/handler/ha_shannon_rapid.cc
@@ -235,8 +235,8 @@ handler::Table_flags ha_rapid::table_flags() const {
    *  used for cost estimates. But, here, we support index too.*/
 
   // return HA_NO_INDEX_ACCESS | HA_STATS_RECORDS_IS_EXACT | HA_COUNT_ROWS_INSTANT;
-  ulong flags =
-      HA_READ_NEXT | HA_READ_PREV | HA_READ_ORDER | HA_READ_RANGE | HA_KEYREAD_ONLY | HA_DO_INDEX_COND_PUSHDOWN;
+  ulong flags = HA_READ_NEXT | HA_READ_PREV | HA_READ_ORDER | HA_READ_RANGE | HA_KEYREAD_ONLY |
+                HA_DO_INDEX_COND_PUSHDOWN | HA_STATS_RECORDS_IS_EXACT | HA_COUNT_ROWS_INSTANT;
   return ~HA_NO_INDEX_ACCESS || flags;
 }
 
@@ -275,16 +275,12 @@ unsigned long ha_rapid::index_flags(unsigned int idx, unsigned int part, bool al
 }
 
 int ha_rapid::records(ha_rows *num_rows) {
-#if 0
   Rapid_load_context context;
   context.m_trx = Transaction::get_or_create_trx(m_thd);
   std::string sch_tb;
   sch_tb.append(table_share->db.str).append(":").append(table_share->table_name.str);
   auto rpd_tb = Imcs::Imcs::instance()->get_table(sch_tb);
-  *num_rows = rpd_tb->first_field()->rows(&context);
-#endif
-
-  ha_get_primary_handler()->ha_records(num_rows);
+  *num_rows = rpd_tb->rows(&context);
   return ShannonBase::SHANNON_SUCCESS;
 }
 


### PR DESCRIPTION
1: in rapid engine, the statement option is set to `OPTION_NO_CONST_TABLES`.
   which will lead to do not do aggregation optimization in frist round optimization
   in `JON::optimze`. And in next round, in the statement will be offload to rapid
   engine. Therefore, we should do aggregation optimization in rapid.

Fixes: #537

I hereby agree to the terms of the CLA available at: http://www.shannondata.ai/doc/cla/

## Summary

_Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR._

- Fixes #537

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):