### PR TITLE
feat(cmake): enhance onnxruntime build

### DIFF
--- a/cmake/FindONNXRuntime.cmake
+++ b/cmake/FindONNXRuntime.cmake
@@ -1,6 +1,16 @@
 # ================================================
 # FindONNXRuntime.cmake
-# A CMake module to find or download ONNX Runtime
+# A CMake module to find or download ONNX Runtime.
+#
+# Priority:
+#   1. Native optimized ONNXRuntime under:
+#        extra/onnxruntime/
+#   2. System installation
+#   3. Official generic ONNXRuntime release package
+#
+# This allows advanced users to provide architecture-optimized
+# ONNXRuntime builds while keeping the default generic package
+# for maximum compatibility.
 # Supports: Linux, macOS, Windows
 # Supports: CPU or GPU builds (based on USE_GPU env)
 # ================================================
@@ -85,7 +95,62 @@ set(_download_path "${CMAKE_BINARY_DIR}/${_archive_name}")
 set(_extract_dir "${CMAKE_BINARY_DIR}/_deps")
 set(_install_dir "${_extract_dir}/onnxruntime")
 
-# Try system-wide ONNX Runtime installation first
+# ============================================================
+# 1. Prefer bundled native optimized ONNXRuntime if available
+# ============================================================
+
+set(_extra_onnxruntime_root
+    "${CMAKE_SOURCE_DIR}/extra/onnxruntime")
+
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64")
+  set(_extra_arch "aarch64")
+elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64")
+  set(_extra_arch "x86_64")
+elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "arm")
+  set(_extra_arch "arm")
+else()
+  set(_extra_arch "${CMAKE_SYSTEM_PROCESSOR}")
+endif()
+
+find_path(ONNXRUNTIME_NATIVE_INCLUDE_DIR
+  NAMES onnxruntime_c_api.h
+  PATHS
+    "${_extra_onnxruntime_root}/include"
+  NO_DEFAULT_PATH)
+
+find_library(ONNXRUNTIME_NATIVE_LIBRARY
+  NAMES onnxruntime
+  PATHS
+    "${_extra_onnxruntime_root}/lib/${_extra_arch}"
+    "${_extra_onnxruntime_root}/lib"
+  NO_DEFAULT_PATH)
+
+if (ONNXRUNTIME_NATIVE_INCLUDE_DIR AND
+    ONNXRUNTIME_NATIVE_LIBRARY)
+
+  set(ONNXRUNTIME_FOUND TRUE)
+
+  set(ONNXRUNTIME_INCLUDE_DIRS
+      ${ONNXRUNTIME_NATIVE_INCLUDE_DIR})
+
+  set(ONNXRUNTIME_LIBRARIES
+      ${ONNXRUNTIME_NATIVE_LIBRARY})
+
+  get_filename_component(
+    ONNXRUNTIME_LIB_DIR
+    ${ONNXRUNTIME_NATIVE_LIBRARY}
+    DIRECTORY)
+
+  message(STATUS
+    "[ONNXRuntime] Using bundled native optimized build: "
+    "${ONNXRUNTIME_NATIVE_LIBRARY}")
+
+  return()
+endif()
+
+# ============================================================
+# 2. Try system-wide ONNX Runtime installation
+# ============================================================
 find_path(ONNXRUNTIME_INCLUDE_DIR onnxruntime_c_api.h 
   PATHS /usr/include /usr/local/include /opt/include
   NO_DEFAULT_PATH)
@@ -97,6 +162,10 @@ if (ONNXRUNTIME_INCLUDE_DIR AND ONNXRUNTIME_LIBRARY)
   set(ONNXRUNTIME_FOUND TRUE)
   set(ONNXRUNTIME_INCLUDE_DIRS ${ONNXRUNTIME_INCLUDE_DIR})
   set(ONNXRUNTIME_LIBRARIES ${ONNXRUNTIME_LIBRARY})
+  get_filename_component(
+    ONNXRUNTIME_LIB_DIR
+    ${ONNXRUNTIME_LIBRARY}
+    DIRECTORY)
   message(STATUS "[ONNXRuntime] Found system installation.")
   return()
 endif()
@@ -106,7 +175,9 @@ if (EXISTS "${_install_dir}")
   message(STATUS "[ONNXRuntime] Found existing installation at ${_install_dir}")
 else()
   # If not found, download the binary archive
-  message(STATUS "[ONNXRuntime] System installation not found. Downloading: ${_onnx_url}")
+  message(STATUS
+    "[ONNXRuntime] No native/system installation found. "
+    "Downloading generic official release: ${_onnx_url}")
 
   file(DOWNLOAD ${_onnx_url} ${_download_path}
        SHOW_PROGRESS STATUS _dl_status)

--- a/extra/onnxruntime/readme.md
+++ b/extra/onnxruntime/readme.md
@@ -1,0 +1,67 @@
+# ONNXRuntime Integration
+
+ShannonBase provides a built-in generic ONNXRuntime package by default, which works out-of-box across supported platforms.
+
+For users who want maximum inference performance on a specific CPU architecture, ShannonBase also supports optional native optimized ONNXRuntime builds.
+
+## Default Behavior
+
+If no custom ONNXRuntime build is provided, the build system automatically downloads and uses the official generic ONNXRuntime release package from Microsoft.
+
+This provides maximum compatibility across environments.
+
+## Optional Native Optimized Build
+
+Advanced users may place a native optimized ONNXRuntime build under:
+
+```text
+extra/onnxruntime/
+  include/
+  lib/
+    x86_64/
+    aarch64/
+```
+
+Create the directories:
+
+```bash
+mkdir -p extra/onnxruntime/include
+mkdir -p extra/onnxruntime/lib/x86_64
+mkdir -p extra/onnxruntime/lib/aarch64
+```
+
+Then copy the native optimized ONNXRuntime build artifacts into the corresponding directories:
+
+* `include/*`
+* `lib/libonnxruntime*`
+
+Example:
+
+```text
+extra/onnxruntime/lib/x86_64/libonnxruntime.so
+```
+
+When a native optimized ONNXRuntime build exists under `extra/onnxruntime`, the build system automatically prefers it over the default generic ONNXRuntime release package.
+
+This allows users to build ONNXRuntime with architecture-specific optimizations such as:
+
+* `-march=native`
+* `-march=znver2`
+* AVX2
+* AVX512
+* VNNI
+* ARMv8 optimized kernels
+
+## Selection Priority
+
+The ONNXRuntime selection order is:
+
+1. Native optimized build under `extra/onnxruntime`
+2. System-wide ONNXRuntime installation
+3. Official generic ONNXRuntime release package
+
+## Notes
+
+Native optimized builds may not be portable across different CPU architectures or machines.
+
+The default generic ONNXRuntime package remains the recommended option for production distribution and maximum compatibility.


### PR DESCRIPTION
cmake: Prefer bundled native ONNX Runtime and improve detection

Update FindONNXRuntime.cmake to prefer an architecture-optimized ONNX Runtime placed in onnxruntime before falling back to a system installation or downloading the generic official release.

Document selection priority in the header (bundled → system → official package). Add bundled native detection (arch detection, include/lib lookup, set include/libs and early return). Record ONNXRUNTIME_LIB_DIR when a system installation is found. Clarify download/status message to indicate fallback to the generic official release.

I hereby agree to the terms of the CLA available at: http://www.shannondata.ai/doc/cla/

## Summary

_Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR._

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):