### PR TITLE
feat(perf):to improve perf of rapid

### DIFF
--- a/mysql-test/suite/secondary_engine/t/shannon_case8.test
+++ b/mysql-test/suite/secondary_engine/t/shannon_case8.test
@@ -54,7 +54,7 @@ INSERT INTO test_non_strict VALUES (1, '0000-00-00', '0000-00-00 00:00:00');
 
 INSERT INTO test_non_strict VALUES (2, '2024-02-30', '2024-02-30 25:61:61');
 
-
+--sleep 1
 SELECT * FROM test_non_strict;
 
 SET sql_mode = 'STRICT_ALL_TABLES';

--- a/storage/rapid_engine/executor/iterators/table_scan_iterator.cpp
+++ b/storage/rapid_engine/executor/iterators/table_scan_iterator.cpp
@@ -116,12 +116,12 @@ void VectorizedTableScanIterator::PreallocateColumnChunks() {
     m_col_chunks.assign(table()->s->fields, ShannonBase::Executor::ColumnChunk(nullptr, 0));
   }
 
+  auto initial_capacity = std::max(m_batch_size, static_cast<size_t>(ShannonBase::SHANNON_ROWS_IN_CHUNK));
+
   uint valid_fields = 0;
   for (uint ind = 0; ind < table()->s->fields; ind++) {
     Field *field = table()->field[ind];
     if (bitmap_is_set(table()->read_set, ind) && !field->is_flag_set(NOT_SECONDARY_FLAG)) {
-      auto initial_capacity =
-          std::max(m_batch_size, static_cast<size_t>(((ShannonBase::SHANNON_ROWS_IN_CHUNK + 7) / 8) + 1));
       m_col_chunks[ind] = ShannonBase::Executor::ColumnChunk(field, initial_capacity);
       valid_fields++;
     }
@@ -131,8 +131,6 @@ void VectorizedTableScanIterator::PreallocateColumnChunks() {
     for (const auto &field : m_active_fields) {
       auto idx = field->field_index();
       if (idx < m_col_chunks.size()) {
-        auto initial_capacity =
-            std::max(m_batch_size, static_cast<size_t>(((ShannonBase::SHANNON_ROWS_IN_CHUNK + 7) / 8) + 1));
         m_col_chunks[idx] = ShannonBase::Executor::ColumnChunk(field, initial_capacity);
       }
     }

--- a/storage/rapid_engine/imcs/cu.cpp
+++ b/storage/rapid_engine/imcs/cu.cpp
@@ -34,14 +34,11 @@
 #include <random>
 #include <sstream>
 
-#if defined(__SSE4_2__)
-#include <nmmintrin.h>
-#endif
-
 #include "sql/field.h"
 #include "sql/field_common_properties.h"
 
 #include "storage/rapid_engine/imcs/imcu.h"
+#include "storage/rapid_engine/utils/crc.h"
 #include "storage/rapid_engine/utils/utils.h"
 /*
    1. Compression (compress / decompress)
@@ -74,50 +71,6 @@
 */
 namespace ShannonBase {
 namespace Imcs {
-//  CRC-32 (ISO 3309, zlib polynomial 0xEDB88320)
-static const std::array<uint32_t, 256> &crc32_table() {
-  static const std::array<uint32_t, 256> table = []() {
-    std::array<uint32_t, 256> t{};
-    static constexpr uint32_t kPoly = 0xEDB88320u;
-    for (uint32_t i = 0; i < t.size(); ++i) {
-      uint32_t crc = i;
-      for (int k = 0; k < 8; ++k) {
-        crc = (crc >> 1) ^ (kPoly & -(crc & 1u));
-      }
-      t[i] = crc;
-    }
-    return t;
-  }();
-  return table;
-}
-
-/* static */
-uint32_t CU::crc32_compute(const void *data, size_t len, uint32_t seed) {
-  const auto *p = static_cast<const uint8_t *>(data);
-  uint32_t crc = ~seed;
-
-#if defined(__SSE4_2__)
-  uint64_t crc64 = static_cast<uint64_t>(crc);
-  while (len >= 8) {
-    uint64_t block = *reinterpret_cast<const uint64_t *>(p);
-    crc64 = _mm_crc32_u64(crc64, block);
-    p += 8;
-    len -= 8;
-  }
-  while (len--) {
-    crc64 = _mm_crc32_u8(static_cast<uint32_t>(crc64), *p++);
-  }
-  crc = static_cast<uint32_t>(crc64);
-#else
-  const auto &table = crc32_table();
-  for (size_t i = 0; i < len; ++i) {
-    crc = (crc >> 8) ^ table[(crc ^ p[i]) & 0xFF];
-  }
-#endif
-
-  return ~crc;
-}
-
 //  CRC-accumulating ostream wrapper used during serialize()
 // We cannot use a real stream transformer easily in vanilla C++, so we buffer
 // a running CRC alongside each write via a thin helper.
@@ -131,7 +84,7 @@ struct CrcStream {
   void write(const void *data, size_t n) {
     if (n == 0) return;
     out.write(reinterpret_cast<const char *>(data), static_cast<std::streamsize>(n));
-    crc = CU::crc32_compute(data, n, crc);
+    crc = Utils::crc32c_compute(data, n, crc);
     bytes_written += n;
   }
 
@@ -150,7 +103,7 @@ struct CrcIStream {
 
   bool read(void *buf, size_t n) {
     if (!in.read(reinterpret_cast<char *>(buf), static_cast<std::streamsize>(n))) return false;
-    crc = CU::crc32_compute(buf, n, crc);
+    crc = Utils::crc32c_compute(buf, n, crc);
     return true;
   }
 

--- a/storage/rapid_engine/imcs/cu.h
+++ b/storage/rapid_engine/imcs/cu.h
@@ -239,9 +239,6 @@ class CU : public MemoryObject {
   const uchar *get_data_address(row_id_t local_row_id) const;
   size_t get_data_size() const;
 
-  /** CRC-32 (ISO 3309 / zlib polynomial 0xEDB88320). */
-  static uint32_t crc32_compute(const void *data, size_t len, uint32_t seed = 0);
-
  private:
   inline bool needs_dictionary() const {
     return (m_header.type == MYSQL_TYPE_VARCHAR || m_header.type == MYSQL_TYPE_STRING ||

--- a/storage/rapid_engine/imcs/imcu.cpp
+++ b/storage/rapid_engine/imcs/imcu.cpp
@@ -36,6 +36,7 @@
 
 #include "storage/rapid_engine/imcs/imcs.h"  // imcs:pool
 #include "storage/rapid_engine/imcs/table.h"
+#include "storage/rapid_engine/include/rapid_const.h"
 #include "storage/rapid_engine/include/rapid_context.h"
 #include "storage/rapid_engine/utils/utils.h"
 
@@ -300,38 +301,53 @@ int Imcu::update_row(const Rapid_load_context *context, row_id_t local_row_id,
 size_t Imcu::scan_range_vectorized(Rapid_scan_context *context, size_t start_offset, size_t limit,
                                    const std::vector<std::unique_ptr<Predicate>> &predicates,
                                    const std::vector<uint32> &projection, RowCallback callback) {
-  size_t num_rows = m_header.current_rows.load();
+#if defined(SHANNON_SCALAR_FALLBACK)
+  static constexpr size_t kScanBatchSize = 64;
+#elif defined(SHANNON_AVX512_VECT_SUPPORTED)
+  static constexpr size_t kScanBatchSize = 8 * SHANNON_VECTOR_WIDTH;
+#else
+  static constexpr size_t kScanBatchSize = 16 * SHANNON_VECTOR_WIDTH;
+#endif
+  static_assert(kScanBatchSize <= 4096, "kScanBatchSize too large: sel[] would exceed safe stack size");
+
+  size_t num_rows = m_header.current_rows.load(std::memory_order_acquire);
   if (start_offset >= num_rows) return 0;
 
-  size_t scanned = 0;
-  std::vector<const uchar *> row_buffer(projection.size());
+  bit_array_t visibility_mask(kScanBatchSize);
+  bit_array_t predicate_mask(kScanBatchSize);
+  uint32_t sel[kScanBatchSize];
 
-  for (size_t start = start_offset; start < num_rows && scanned < limit; start += SHANNON_VECTOR_WIDTH) {
-    size_t end = std::min(start + SHANNON_VECTOR_WIDTH, num_rows);
-    size_t batch_size = end - start;
-    bit_array_t visibility_mask(batch_size);
+  const size_t proj_size = projection.size();
+  std::vector<const uchar *> row_buffer(proj_size);
+
+  size_t scanned = 0;
+
+  for (size_t start = start_offset; start < num_rows && scanned < limit; start += kScanBatchSize) {
+    const size_t batch_size = std::min(kScanBatchSize, num_rows - start);
+    visibility_mask.reset();
     check_visibility_batch(context, static_cast<row_id_t>(start), batch_size, visibility_mask);
 
-    bit_array_t predicate_mask(batch_size);
+    predicate_mask.reset();
     if (!predicates.empty()) {
       evaluate_predicates_vectorized(predicates, start, batch_size, predicate_mask);
       predicate_mask.and_with(visibility_mask);
     } else {
-      std::memcpy(predicate_mask.data, visibility_mask.data, predicate_mask.size);
+      const size_t byte_count = (batch_size + 7) / 8;
+      std::memcpy(predicate_mask.data, visibility_mask.data, byte_count);
     }
 
-    if (predicate_mask.is_all_false()) {
-      scanned += batch_size;
-      continue;
-    }
+    scanned += batch_size;
+    if (predicate_mask.is_all_false()) continue;
 
+    size_t sel_count = 0;
     for (size_t i = 0; i < batch_size; ++i) {
-      scanned++;
-      if (!Utils::Util::bit_array_get(&predicate_mask, i)) continue;  // not match
+      if (Utils::Util::bit_array_get(&predicate_mask, i)) sel[sel_count++] = static_cast<uint32_t>(i);
+    }
 
-      row_id_t local_row_id = start + i;
-      for (size_t j = 0; j < projection.size(); ++j) {
-        uint32 col_idx = projection[j];
+    for (size_t idx = 0; idx < sel_count; ++idx) {
+      const row_id_t local_row_id = start + sel[idx];
+      for (size_t j = 0; j < proj_size; ++j) {
+        const uint32 col_idx = projection[j];
         if (Utils::Util::bit_array_get(m_header.null_masks[col_idx].get(), local_row_id)) {
           row_buffer[j] = nullptr;
         } else {
@@ -340,13 +356,15 @@ size_t Imcu::scan_range_vectorized(Rapid_scan_context *context, size_t start_off
         }
       }
 
-      row_id_t global_row_id = m_header.start_row + local_row_id;
+      const row_id_t global_row_id = m_header.start_row + local_row_id;
       callback(global_row_id, row_buffer);
       context->rows_returned++;
       if (context->limit > 0 && context->rows_returned >= context->limit) return scanned;
-      if (scanned >= limit) break;
     }
+
+    if (scanned >= limit) break;
   }
+
   return scanned;
 }
 
@@ -375,7 +393,7 @@ void Imcu::evaluate_compound_predicate_vectorized(const Compound_Predicate *pred
   switch (pred->op) {
     case PredicateOperator::AND: {
       result.set();
-      bit_array_t child_result(num_rows);
+      bit_array_t child_result = result.clone_empty();
       for (const auto &child : pred->children) {
         if (!child) continue;
         child_result.reset();  // clear before each child evaluation
@@ -389,7 +407,7 @@ void Imcu::evaluate_compound_predicate_vectorized(const Compound_Predicate *pred
     } break;
     case PredicateOperator::OR: {
       result.reset();
-      bit_array_t child_result(num_rows);
+      bit_array_t child_result = result.clone_empty();
       for (const auto &child : pred->children) {
         if (!child) continue;
         child_result.reset();

--- a/storage/rapid_engine/imcs/imcu.h
+++ b/storage/rapid_engine/imcs/imcu.h
@@ -66,7 +66,6 @@
 #include "storage/rapid_engine/imcs/row0row.h"
 #include "storage/rapid_engine/imcs/storage0index.h"
 #include "storage/rapid_engine/include/rapid_config.h"
-#include "storage/rapid_engine/include/rapid_const.h"
 #include "storage/rapid_engine/include/rapid_types.h"
 #include "storage/rapid_engine/trx/transaction.h"  // Transaction_Journal
 #include "storage/rapid_engine/utils/memory_pool.h"

--- a/storage/rapid_engine/imcs/table0view.cpp
+++ b/storage/rapid_engine/imcs/table0view.cpp
@@ -124,8 +124,8 @@ void RapidCursor::init_col_chunks() {
   m_col_chunks.clear();
   m_col_chunks.reserve(m_data_source->s->fields);
 
-  const size_t cap = std::max(static_cast<size_t>(SHANNON_BATCH_NUM),
-                              static_cast<size_t>(((ShannonBase::SHANNON_ROWS_IN_CHUNK + 7) / 8) + 1));
+  const size_t cap =
+      std::max(static_cast<size_t>(SHANNON_BATCH_NUM), static_cast<size_t>(ShannonBase::SHANNON_ROWS_IN_CHUNK));
 
   for (uint ind = 0; ind < m_data_source->s->fields; ++ind) {
     Field *fld = m_data_source->field[ind];
@@ -201,6 +201,8 @@ int RapidCursor::next(uchar *buf) {
   // Refill the column-chunk batch whenever the current one is exhausted.
   if (m_scan_state.is_exhausted()) {
     if (m_scan_state.exhausted.load(std::memory_order_acquire)) return HA_ERR_END_OF_FILE;
+
+    for (auto &chunk : m_col_chunks) chunk.clear();
 
     size_t read_cnt = 0;
     int result = next(SHANNON_BATCH_NUM, m_col_chunks, read_cnt);
@@ -562,7 +564,8 @@ void ColumnChunkRecv::on_row(row_id_t, const std::vector<const uchar *> &row_dat
     auto col_idx = projection_cols[idx];
     auto &chunk = chunks[col_idx];
     auto normal_len = cursor->table()->meta().fields[col_idx].normalized_length;
-    chunk.add(row_data[idx], normal_len, row_data[idx] == nullptr);
+
+    if (!chunk.add(row_data[idx], normal_len, row_data[idx] == nullptr)) return;  // chunk full.
   }
   ++read_cnt;
 }

--- a/storage/rapid_engine/include/rapid_const.h
+++ b/storage/rapid_engine/include/rapid_const.h
@@ -31,61 +31,111 @@
 #include "my_inttypes.h"
 #include "rapid_arch_inf.h"
 
+// clang-format off
 #if defined(__APPLE__) && defined(__arm64__)
-#define SHANNON_APPLE_PLATFORM
-#define SHANNON_ARM_PLATFORM
-#include <arm_neon.h>
-#define SHANNON_ARM_VECT_SUPPORTED
+    #define SHANNON_APPLE_PLATFORM
+    #define SHANNON_ARM_PLATFORM
 
+    static_assert(__ARM_NEON, "Expected NEON on Apple arm64 but __ARM_NEON is unset");
+    #include <arm_neon.h>
+    #define SHANNON_ARM_VECT_SUPPORTED
 #elif defined(__arm__) || defined(__aarch64__)
-#define SHANNON_ARM_PLATFORM
-#if defined(__ARM_NEON) || defined(__ARM_NEON__)
-#include <arm_neon.h>
-#define SHANNON_ARM_VECT_SUPPORTED
-#endif
+    #define SHANNON_ARM_PLATFORM
 
-#elif defined(__x86_64__) || defined(__i386__) || defined(_M_X64)
-#define SHANNON_X86_PLATFORM
-
-#if defined(__AVX2__) || defined(__AVX__)
-#include <immintrin.h>
-#define SHANNON_AVX_VECT_SUPPORTED
-#elif defined(__SSE4_2__) || defined(__SSE4_1__) || defined(__SSE2__) || defined(__SSE__)
-#include <emmintrin.h>
-#define SHANNON_SSE_VECT_SUPPORTED
-#endif
-
-#elif defined(_WIN32)
-#define SHANNON_WIN_PLATFORM
-#if defined(__AVX2__) || defined(__AVX__)
-#include <immintrin.h>
-#define SHANNON_AVX_VECT_SUPPORTED
-#elif defined(_M_IX86_FP) && _M_IX86_FP >= 2
-#include <emmintrin.h>
-#define SHANNON_SSE_VECT_SUPPORTED
-#endif
-
+    #if defined(__ARM_NEON) || defined(__ARM_NEON__)
+        #include <arm_neon.h>
+        #define SHANNON_ARM_VECT_SUPPORTED
+    #endif
+    #if defined(__ARM_FEATURE_SVE)
+        #include <arm_sve.h>
+        #define SHANNON_ARM_SVE_SUPPORTED
+    #endif
+#elif defined(__x86_64__) || defined(__i386__) || defined(_M_X64) || defined(_M_IX86)
+    #define SHANNON_X86_PLATFORM
+     #if defined(_MSC_VER)
+        #if defined(__AVX512F__) && defined(__AVX512BW__)
+            #include <immintrin.h>
+            #define SHANNON_AVX512_VECT_SUPPORTED
+            // AVX-512 implies AVX2/SSE4.2; hardware CRC32 is available.
+            #define SHANNON_CRC32_HW_SUPPORTED
+            #if defined(_M_X64)
+                #define SHANNON_CRC32_U64_SUPPORTED
+            #endif
+        #elif defined(__AVX2__) || defined(__AVX__)
+            #include <immintrin.h>
+            #define SHANNON_AVX_VECT_SUPPORTED
+            // /arch:AVX[2] makes SSE4.2 intrinsics available on MSVC.
+            #define SHANNON_CRC32_HW_SUPPORTED
+            #if defined(_M_X64)
+                #define SHANNON_CRC32_U64_SUPPORTED
+            #endif
+        #elif defined(_M_IX86_FP) && (_M_IX86_FP >= 2)
+            // /arch:SSE2 — only SSE2 guaranteed; no CRC32.
+            #include <emmintrin.h>
+            #define SHANNON_SSE_VECT_SUPPORTED
+        #endif  // MSVC arch tiers
+    #else // GCC / Clang
+        #if defined(__AVX512F__) && defined(__AVX512BW__)
+            #include <immintrin.h>
+            #define SHANNON_AVX512_VECT_SUPPORTED
+            // AVX-512 supersets AVX2; also implies SSE4.2 / CRC32.
+            #define SHANNON_CRC32_HW_SUPPORTED
+            #if defined(__x86_64__)
+                #define SHANNON_CRC32_U64_SUPPORTED
+            #endif
+        #elif defined(__AVX2__) || defined(__AVX__)
+            #include <immintrin.h>
+            #define SHANNON_AVX_VECT_SUPPORTED
+        #endif  // AVX tiers
+         #if defined(__SSE4_2__)
+            #include <nmmintrin.h>
+            #define SHANNON_CRC32_HW_SUPPORTED
+            #if defined(__x86_64__)
+                #define SHANNON_CRC32_U64_SUPPORTED
+            #endif
+            // Only promote to SSE vector path when AVX is absent.
+            #if !defined(SHANNON_AVX_VECT_SUPPORTED) &&  !defined(SHANNON_AVX512_VECT_SUPPORTED)
+                #define SHANNON_SSE_VECT_SUPPORTED
+            #endif
+        #elif defined(__SSE4_1__) || defined(__SSE2__) || defined(__SSE__)
+            #if !defined(SHANNON_AVX_VECT_SUPPORTED) &&  !defined(SHANNON_AVX512_VECT_SUPPORTED)
+                #include <emmintrin.h>
+                #define SHANNON_SSE_VECT_SUPPORTED
+            #endif
+        #endif  // SSE tiers
+    #endif  // _MSC_VER
 #else
-#error "Unsupported platform for ShannonBase"
+    #error "Unsupported platform for ShannonBase"
+#endif  // platform
+
+#if defined(SHANNON_SSE_VECT_SUPPORTED)   ||  defined(SHANNON_AVX_VECT_SUPPORTED)   || \
+    defined(SHANNON_AVX512_VECT_SUPPORTED)||  defined(SHANNON_ARM_VECT_SUPPORTED)   || \
+    defined(SHANNON_ARM_SVE_SUPPORTED)
+    #define SHANNON_VECTORIZE_SUPPORT
 #endif
 
-#if (defined(SHANNON_ARM_PLATFORM) && defined(SHANNON_X86_PLATFORM)) || \
-    (defined(SHANNON_ARM_PLATFORM) && defined(SHANNON_WIN_PLATFORM)) || \
-    (defined(SHANNON_X86_PLATFORM) && defined(SHANNON_WIN_PLATFORM))
-#error "Conflicting platform macros detected!"
+#if defined(SHANNON_AVX512_VECT_SUPPORTED)
+    #define SHANNON_VECTOR_WIDTH 512
+#elif defined(SHANNON_AVX_VECT_SUPPORTED)
+    #define SHANNON_VECTOR_WIDTH 256
+#elif defined(SHANNON_SSE_VECT_SUPPORTED)
+    #define SHANNON_VECTOR_WIDTH 128
+#elif defined(SHANNON_ARM_VECT_SUPPORTED) || defined(SHANNON_ARM_SVE_SUPPORTED)
+    #define SHANNON_VECTOR_WIDTH 128    // NEON = 128-bit; SVE >= 128-bit
+#else
+    #define SHANNON_VECTOR_WIDTH  64
+    #define SHANNON_SCALAR_FALLBACK
 #endif
+
+#if defined(SHANNON_ARM_PLATFORM) && defined(__ARM_FEATURE_CRC32)
+    #define SHANNON_ARM_CRC32_SUPPORTED
+    #if defined(__aarch64__)
+        #define SHANNON_CRC32_U64_SUPPORTED   // __crc32cd available
+    #endif
+#endif
+// clang-format on
 
 #define SHANNON_ALIGNAS alignas(CACHE_LINE_SIZE)
-
-#if defined(SHANNON_SSE_VECT_SUPPORTED) || defined(SHANNON_AVX_VECT_SUPPORTED) || defined(SHANNON_ARM_VECT_SUPPORTED)
-#define SHANNON_VECTORIZE_SUPPORT
-#endif
-
-#if defined(SHANNON_X86_PLATFORM)
-#define SHANNON_VECTOR_WIDTH 256  // x86 AVX2
-#elif defined(SHANNON_ARM_PLATFORM)
-#define SHANNON_VECTOR_WIDTH 128  // ARM NEON
-#endif
 
 extern char *mysql_llm_home_ptr;
 namespace ShannonBase {

--- a/storage/rapid_engine/include/rapid_types.h
+++ b/storage/rapid_engine/include/rapid_types.h
@@ -106,6 +106,12 @@ typedef struct alignas(CACHE_LINE_SIZE) BitArray {
     std::memset(data, 0x0, size);
   }
 
+  inline BitArray clone_empty() const {
+    BitArray b(size * 8);
+    b.reset();
+    return b;
+  }
+
   void not_inplace() {
     if (!data || !size) return;
 #ifdef SHANNON_AVX_VECT_SUPPORTED

--- a/storage/rapid_engine/populate/log_populate.cpp
+++ b/storage/rapid_engine/populate/log_populate.cpp
@@ -92,7 +92,7 @@ struct table_worker_context {
   std::condition_variable cv;
   std::chrono::steady_clock::time_point last_activity;
 
-  std::unordered_map<uint64_t, change_record_buff_t> pending_records;
+  std::vector<change_candidate_t> pending_change_candidates;
   std::atomic<size_t> pending_size{0};
 
   // lsn<---> retry_counts
@@ -122,11 +122,11 @@ uint64_t get_populator_worker_pending_bytes() noexcept {
 
 static void table_worker_func(table_worker_context *ctx) {
 #if !defined(_WIN32)
-  std::string thread_name = "rapid_change_table_worker_" + std::to_string(ctx->table_key);
-  pthread_setname_np(pthread_self(), thread_name.c_str());
+  const std::string tname = "rapid_change_worker_" + std::to_string(ctx->table_key);
+  pthread_setname_np(pthread_self(), tname.c_str());
 #else
-  std::wstring thread_name = L"rapid_change_table_worker_" + std::to_string(ctx->table_key);
-  SetThreadDescription(GetCurrentThread(), thread_name.c_str());
+  const std::wstring tname = L"rapid_change_worker_" + std::to_wstring(ctx->table_key);
+  SetThreadDescription(GetCurrentThread(), tname.c_str());
 #endif
 
   THD *thd = create_internal_thd();
@@ -154,113 +154,128 @@ static void table_worker_func(table_worker_context *ctx) {
   context.m_thd = thd;
 
   while (!ctx->should_stop.load(std::memory_order_acquire)) {
-    std::unique_lock<std::mutex> lock(ctx->mtx);
-    ctx->cv.wait_for(lock, std::chrono::milliseconds(TABLE_WORKER_IDLE_TIMEOUT),
-                     [ctx] { return ctx->should_stop.load() || ctx->pending_size.load() > 0; });
-    if (ctx->should_stop.load()) break;
+    bool should_exit = false;
+    {
+      std::unique_lock<std::mutex> lk(ctx->mtx);
+      ctx->cv.wait_for(lk, std::chrono::milliseconds(TABLE_WORKER_IDLE_TIMEOUT), [ctx] {
+        return ctx->should_stop.load(std::memory_order_acquire) ||
+               ctx->pending_size.load(std::memory_order_acquire) > 0;
+      });
 
-    auto idle =
-        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - ctx->last_activity)
-            .count();
-    if ((uint64_t)idle >= TABLE_WORKER_IDLE_TIMEOUT && ctx->pending_size.load() == 0) break;
-
-    std::unordered_map<uint64_t, change_record_buff_t> applying;
-    std::unordered_map<uint64_t, change_record_buff_t> failed;
-    size_t applied_size = 0;
-    if (ctx->pending_size.load() > 0) {
-      std::swap(applying, ctx->pending_records);
-      ctx->pending_records.clear();
-      ctx->pending_size.store(0, std::memory_order_release);
-      size_t total_batch_size = ctx->pending_size.load(std::memory_order_relaxed);
-      shannon_pop_data_sz.fetch_sub(total_batch_size, std::memory_order_release);
+      if (ctx->should_stop.load(std::memory_order_acquire)) {
+        should_exit = true;
+      } else {
+        const auto idle =
+            std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - ctx->last_activity)
+                .count();
+        if (static_cast<uint64_t>(idle) >= TABLE_WORKER_IDLE_TIMEOUT &&
+            ctx->pending_size.load(std::memory_order_acquire) == 0) {
+          should_exit = true;
+        }
+      }
     }
-    lock.unlock();
+    if (should_exit) break;
 
+    std::vector<change_candidate_t> applying;
+    {
+      std::lock_guard<std::mutex> lk(ctx->mtx);
+      if (ctx->pending_size.load(std::memory_order_acquire) > 0) {
+        std::swap(applying, ctx->pending_change_candidates);
+        ctx->pending_size.store(0, std::memory_order_release);
+      }
+    }
     if (applying.empty()) continue;
 
-    for (auto &[lsn, change_rec] : applying) {
+    const bool has_copy_info = std::any_of(applying.begin(), applying.end(), [](const change_candidate_t &c) {
+      return c.record.m_source == Source::COPY_INFO;
+    });
+
+    if (has_copy_info) {
+      context.m_trx = Transaction::get_or_create_trx(thd);
+      context.m_trx->begin();
+      context.m_extra_info.m_trxid = context.m_trx->get_id();
+    }
+
+    std::vector<change_candidate_t> failed_vec;
+    for (auto &candidate : applying) {
+      const uint64_t lsn = candidate.lsn;
+      change_record_buff_t &rec = candidate.record;
       size_t parsed_bytes = 0;
-      if (change_rec.m_source == ShannonBase::Populate::Source::REDO_LOG) {
-        const byte *start = change_rec.m_buff0.get();
-        const byte *end = start + change_rec.m_size;
+
+      if (rec.m_source == Source::REDO_LOG) {
+        // redo log: parse_redo manages its own transaction internally
+        const byte *start = rec.m_buff0.get();
+        const byte *end = start + rec.m_size;
         parsed_bytes = parse_log.parse_redo(&context, const_cast<byte *>(start), const_cast<byte *>(end));
         assert(parsed_bytes == size_t(end - start));
-      } else if (change_rec.m_source == ShannonBase::Populate::Source::COPY_INFO) {
-        auto oper_type = change_rec.m_oper;
+
+      } else if (rec.m_source == Source::COPY_INFO) {
 #ifndef NDEBUG
-        context.m_schema_name = change_rec.m_schema_name;
-        context.m_table_name = change_rec.m_table_name;
+        context.m_schema_name = rec.m_schema_name;
+        context.m_table_name = rec.m_table_name;
         context.m_sch_tb_name = context.m_schema_name + "." + context.m_table_name;
 #endif
-        context.m_offpage_data0 = change_rec.m_offpage_data0.empty() ? nullptr : &change_rec.m_offpage_data0;
-        context.m_offpage_data1 = change_rec.m_offpage_data1.empty() ? nullptr : &change_rec.m_offpage_data1;
+        context.m_offpage_data0 = rec.m_offpage_data0.empty() ? nullptr : &rec.m_offpage_data0;
+        context.m_offpage_data1 = rec.m_offpage_data1.empty() ? nullptr : &rec.m_offpage_data1;
 
-        context.m_trx = Transaction::get_or_create_trx(thd);
-        context.m_trx->begin();
-        context.m_extra_info.m_trxid = context.m_trx->get_id();
-
-        const byte *old_start = change_rec.m_buff0.get();
-        const byte *old_end = old_start + change_rec.m_size;
-        const byte *new_start = change_rec.m_buff1.get();
-        const byte *new_end = new_start + change_rec.m_size;
-        parsed_bytes = copy_info_log.parse_copy_info(&context, change_rec.m_table_id, oper_type,
+        const byte *old_start = rec.m_buff0.get();
+        const byte *old_end = old_start + rec.m_size;
+        const byte *new_start = rec.m_buff1.get();
+        const byte *new_end = new_start + rec.m_size;
+        parsed_bytes = copy_info_log.parse_copy_info(&context, rec.m_table_id, rec.m_oper,
                                                      const_cast<byte *>(old_start), const_cast<byte *>(old_end),
                                                      const_cast<byte *>(new_start), const_cast<byte *>(new_end));
-        ShannonBase::Imcs::RpdTable *rpd_tb{nullptr};
-        rpd_tb = Imcs::Imcs::instance()->get_rpd_parttable(change_rec.m_table_id);
-        if (rpd_tb)
-          rpd_tb->register_transaction(context.m_trx);
-        else {
-          rpd_tb = Imcs::Imcs::instance()->get_rpd_table(change_rec.m_table_id);
-          if (rpd_tb) rpd_tb->register_transaction(context.m_trx);
-        }
-        context.m_trx->commit();
       }
 
-      if (parsed_bytes == change_rec.m_size) {
-        applied_size += change_rec.m_size;
+      if (parsed_bytes == rec.m_size) {
         ctx->retry_counts.erase(lsn);
       } else {
-        uint32_t current_retry = ++ctx->retry_counts[lsn];
-        if (current_retry <= MAX_RETRY_COUNT) {
+        const uint32_t retry = ++ctx->retry_counts[lsn];
+        if (retry <= MAX_RETRY_COUNT) {
           push_warning_printf(thd, Sql_condition::SL_WARNING, ER_SECONDARY_ENGINE,
                               "Propagation failed for table %ld at LSN %lu (retry %u/%u), retrying...", ctx->table_key,
-                              lsn, current_retry, MAX_RETRY_COUNT);
-          failed.emplace(lsn, std::move(change_rec));
+                              lsn, retry, MAX_RETRY_COUNT);
+          failed_vec.push_back(std::move(candidate));  // lsn + record both preserved
         } else {
-          // has over max-try-count, the discard re-trying.
           push_warning_printf(thd, Sql_condition::SL_WARNING, ER_SECONDARY_ENGINE,
                               "Propagation failed for table %ld at LSN %lu after %u retries, dropping record",
                               ctx->table_key, lsn, MAX_RETRY_COUNT);
           ctx->retry_counts.erase(lsn);
-          applied_size += change_rec.m_size;  // substract from pending_size.
         }
       }
     }
 
-    if (!failed.empty()) {
-      std::lock_guard<std::mutex> lock(ctx->mtx);
-      for (auto &p : failed) {
-        ctx->pending_records.emplace(p.first, std::move(p.second));
-        ctx->pending_size.fetch_add(p.second.m_size);
-      }
+    if (has_copy_info && context.m_trx) {
+      // all records belong to table_key, one register_transaction suffices
+      auto *rpd_tb = Imcs::Imcs::instance()->get_rpd_parttable(ctx->table_key);
+      if (!rpd_tb) rpd_tb = Imcs::Imcs::instance()->get_rpd_table(ctx->table_key);
+      if (rpd_tb) rpd_tb->register_transaction(context.m_trx);
+      context.m_trx->commit();
+    }
+
+    if (!failed_vec.empty()) {
+      size_t failed_sz = 0;
+      for (const auto &c : failed_vec) failed_sz += c.record.m_size;
+
+      std::lock_guard<std::mutex> lk(ctx->mtx);
+      ctx->pending_change_candidates.insert(ctx->pending_change_candidates.end(),
+                                            std::make_move_iterator(failed_vec.begin()),
+                                            std::make_move_iterator(failed_vec.end()));
+      ctx->pending_size.fetch_add(failed_sz, std::memory_order_release);
       ctx->cv.notify_one();
     }
 
     {
-      std::lock_guard<std::mutex> lock(ctx->mtx);
+      std::lock_guard<std::mutex> lk(ctx->mtx);
       ctx->last_activity = std::chrono::steady_clock::now();
     }
-  }  // end while.
+  }
 
   {
-    std::unique_lock<std::shared_mutex> lock(table_workers_mutex);
+    std::unique_lock<std::shared_mutex> lk(table_workers_mutex);
     auto it = table_workers.find(ctx->table_key);
-    if (it != table_workers.end() && it->second.get() == ctx) {
-      table_workers.erase(it);
-    }
+    if (it != table_workers.end() && it->second.get() == ctx) table_workers.erase(it);
   }
-  close_thread_tables(thd);
 }
 
 table_worker_context *table_worker_context::get_or_create_table_worker(const table_id_t &table_key) {
@@ -301,7 +316,7 @@ static void parse_log_func_main(log_t *log_ptr) {
   // ref: https://dev.mysql.com/doc/heatwave/en/mys-hw-change-propagation.html
   while (srv_shutdown_state.load(std::memory_order_acquire) == SRV_SHUTDOWN_NONE &&
          shannon_propagation_thread_started.load(std::memory_order_acquire)) {
-    const auto wait_deadline = std::chrono::steady_clock::now() + std::chrono::microseconds{POP_MAX_WAIT_TIMEOUT};
+    const auto wait_deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds{POP_MAX_WAIT_TIMEOUT};
     auto stop_condition = [&](bool wait) {
       for (auto &shard : shannon_pop_shards) {
         std::shared_lock<std::shared_mutex> lk(shard.mutex);
@@ -325,7 +340,7 @@ static void parse_log_func_main(log_t *log_ptr) {
       return false;
     };
 
-    os_event_wait_for(log_ptr->rapid_events[0], 0, std::chrono::microseconds{POP_MAX_WAIT_TIMEOUT}, stop_condition);
+    os_event_wait_for(log_ptr->rapid_events[0], 0, std::chrono::milliseconds{POP_MAX_WAIT_TIMEOUT}, stop_condition);
     os_event_reset(log_sys->rapid_events[0]);
 
     if (!shannon_propagation_thread_started.load()) break;
@@ -343,28 +358,29 @@ static void parse_log_func_main(log_t *log_ptr) {
     if (tables_to_flush.empty()) continue;
 
     for (auto &[table_key, tbuf] : tables_to_flush) {
-      change_candidate_t batch[BATCH_PROCESS_NUM];
-      std::unordered_map<uint64_t, change_record_buff_t> applying;
-      size_t count = 0;
+      std::vector<change_candidate_t> batch_vec;
+      batch_vec.reserve(BATCH_PROCESS_NUM);
 
+      change_candidate_t batch[BATCH_PROCESS_NUM];
+      size_t count = 0;
       while ((count = tbuf->change_candiates.try_pop_bulk(batch, BATCH_PROCESS_NUM)) > 0) {
         for (size_t i = 0; i < count; ++i) {
-          size_t sz = batch[i].record.m_size;
-          tbuf->data_size.fetch_sub(sz, std::memory_order_relaxed);
-          shannon_pop_data_sz.fetch_sub(sz, std::memory_order_relaxed);
-          applying.emplace(batch[i].lsn, std::move(batch[i].record));
+          tbuf->data_size.fetch_sub(batch[i].record.m_size, std::memory_order_relaxed);
+          shannon_pop_data_sz.fetch_sub(batch[i].record.m_size, std::memory_order_relaxed);
+          batch_vec.push_back(std::move(batch[i]));
         }
       }
-      if (applying.empty()) continue;
 
       auto *worker = table_worker_context::get_or_create_table_worker(table_key);
       {
         std::lock_guard lock(worker->mtx);
-        for (auto &p : applying) {
-          worker->pending_size.fetch_add(p.second.m_size);
-          worker->pending_records.emplace(p.first, std::move(p.second));
-        }
-        worker->last_activity = std::chrono::steady_clock::now();
+        worker->pending_change_candidates.insert(worker->pending_change_candidates.end(),
+                                                 std::make_move_iterator(batch_vec.begin()),
+                                                 std::make_move_iterator(batch_vec.end()));
+        worker->pending_size.fetch_add(
+            std::accumulate(batch_vec.begin(), batch_vec.end(), size_t{0},
+                            [](size_t s, const change_candidate_t &c) { return s + c.record.m_size; }),
+            std::memory_order_release);
         worker->cv.notify_one();
       }
     }

--- a/storage/rapid_engine/populate/log_populate.h
+++ b/storage/rapid_engine/populate/log_populate.h
@@ -80,8 +80,8 @@ that's performance issue. in future, we will use co-rountine to process every
 item by a co-routine to promot the performance.
 */
 
-constexpr uint64 POP_MAX_WAIT_TIMEOUT = 200;         // main worker, timeout time in ms.
-constexpr uint64 TABLE_WORKER_IDLE_TIMEOUT = 30000;  // if 30s no incoming new data,the exit the table-level workers.
+constexpr uint64 POP_MAX_WAIT_TIMEOUT = 200;        // main worker, timeout time in ms.
+constexpr uint64 TABLE_WORKER_IDLE_TIMEOUT = 5000;  // if 5s no incoming new data,the exit the table-level workers.
 constexpr uint16_t BATCH_PROCESS_NUM = 256;
 /**
  * key, (uint64_t)lsn_t, start lsn of this mtr record. a change_record_buff_t is consisted of

--- a/storage/rapid_engine/utils/crc.h
+++ b/storage/rapid_engine/utils/crc.h
@@ -1,0 +1,99 @@
+/**
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License, version 2.0,
+   as published by the Free Software Foundation.
+
+   This program is also distributed with certain software (including
+   but not limited to OpenSSL) that is licensed under separate terms,
+   as designated in a particular file or component or in included license
+   documentation.  The authors of MySQL hereby grant you an additional
+   permission to link the program and your derivative works with the
+   separately licensed software that they have included with MySQL.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License, version 2.0, for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+
+   The fundmental code for imcs.
+
+   Copyright (c) 2023, Shannon Data AI and/or its affiliates.
+*/
+#ifndef __SHANNONBASE_CRC_H__
+#define __SHANNONBASE_CRC_H__
+#include <array>
+#include <cstdint>
+#include <cstring>
+
+#include "storage/rapid_engine/include/rapid_const.h"
+namespace ShannonBase {
+namespace Utils {
+#if !defined(SHANNON_CRC32_HW_SUPPORTED)
+// Software table (CRC32C)
+static const std::array<uint32_t, 256> &crc32c_table() {
+  static const std::array<uint32_t, 256> table = []() {
+    std::array<uint32_t, 256> t{};
+    constexpr uint32_t kPoly = 0x82F63B78u;  // CRC32C
+
+    for (uint32_t i = 0; i < 256; ++i) {
+      uint32_t crc = i;
+      for (int k = 0; k < 8; ++k) crc = (crc >> 1) ^ (kPoly & -(crc & 1u));
+      t[i] = crc;
+    }
+    return t;
+  }();
+  return table;
+}
+#endif
+
+#if defined(SHANNON_CRC32_HW_SUPPORTED)
+__attribute__((target("sse4.2")))
+#endif
+uint32_t
+crc32c_compute(const void *data, size_t len, uint32_t seed) {
+  const uint8_t *p = static_cast<const uint8_t *>(data);
+  uint32_t crc = ~seed;
+
+#if defined(SHANNON_CRC32_HW_SUPPORTED)
+  // ---- 64-bit fast path ----
+#if defined(SHANNON_CRC32_U64_SUPPORTED)
+  uint64_t crc64 = crc;
+
+  while (len >= 8) {
+    uint64_t v;
+    memcpy(&v, p, sizeof(v));
+    crc64 = _mm_crc32_u64(crc64, v);
+    p += 8;
+    len -= 8;
+  }
+
+  crc = static_cast<uint32_t>(crc64);
+#endif
+  // ---- 32-bit ----
+  while (len >= 4) {
+    uint32_t v;
+    memcpy(&v, p, sizeof(v));
+    crc = _mm_crc32_u32(crc, v);
+    p += 4;
+    len -= 4;
+  }
+
+  while (len--) {
+    crc = _mm_crc32_u8(crc, *p++);
+  }
+
+#else
+  const auto &table = crc32c_table();
+  while (len--) {
+    crc = (crc >> 8) ^ table[(crc ^ *p++) & 0xFF];
+  }
+#endif
+  return ~crc;
+}
+}  // namespace Utils
+}  // namespace ShannonBase
+#endif  // __SHANNONBASE_CRC_H__


### PR DESCRIPTION
1: correct wait-time unit in parse_log_func_main

Use std::chrono::milliseconds instead of std::chrono::microseconds for POP_MAX_WAIT_TIMEOUT in parse_log_func_main and os_event_wait_for, aligning the timeout with the intended interval.

2: refactor CRC implement.

3: refactor the header file about SIMD usage.

4: reduce memory opers in log propagation workers.

Issues:#725

I hereby agree to the terms of the CLA available at: http://www.shannondata.ai/doc/cla/

## Summary

_Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR._

- Fixes #725 

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):