### PR TITLE
feat(bug): prevent spurious LocalAgg nesting in AggregationPushDown

### DIFF
--- a/mysql-test/suite/secondary_engine/r/shannon_large_data_index.result
+++ b/mysql-test/suite/secondary_engine/r/shannon_large_data_index.result
@@ -18,6 +18,8 @@ alter table SUPPLIER change S_COMMENT S_COMMENT VARCHAR(101) NOT NULL COMMENT 'R
 alter table SUPPLIER change S_COMMENT S_COMMENT VARCHAR(101) NOT NULL COMMENT 'RAPID_COLUMN=ENCODING=VARLEN';
 count(*)
 40000
+sum(S_ACCTBAL)
+180625222.15
 set global rapid_schema_embedding=ON;
 show variables like "%rapid%";
 Variable_name	Value
@@ -78,5 +80,21 @@ id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered
 select * from SUPPLIER where S_ACCTBAL = 5755.94;
 S_SUPPKEY	S_NAME	S_ADDRESS	S_NATIONKEY	S_PHONE	S_ACCTBAL	S_COMMENT
 1	Supplier#000000001	 N kD4on9OM Ipw3,gf0JBoQDd7tgrzrddZ	17	27-918-335-1736	5755.94	each slyly above the careful
+explain format=tree select sum(S_ACCTBAL) from SUPPLIER;
+EXPLAIN
+-> Aggregate: sum(SUPPLIER.S_ACCTBAL)
+    -> Vectorized table scan on SUPPLIER in secondary engine Rapid
+
+set use_secondary_engine =forced;
+explain format=tree select sum(S_ACCTBAL) from SUPPLIER;
+EXPLAIN
+-> Aggregate: sum(SUPPLIER.S_ACCTBAL)
+    -> Vectorized table scan on SUPPLIER in secondary engine Rapid
+
+Warnings:
+Note	1003	Query is executed in secondary engine; the actual query plan may diverge from the printed one
+select sum(S_ACCTBAL) from SUPPLIER;
+sum(S_ACCTBAL)
+180625222.15
 set global rapid_schema_embedding=OFF;
 drop database tpch_1024;

--- a/mysql-test/suite/secondary_engine/t/shannon_large_data_index.test
+++ b/mysql-test/suite/secondary_engine/t/shannon_large_data_index.test
@@ -31,6 +31,7 @@ alter table SUPPLIER change S_COMMENT S_COMMENT VARCHAR(101) NOT NULL COMMENT 'R
 --disable_query_log
 --eval LOAD DATA INFILE '$MYSQLTEST_VARDIR/std_data/supplier.tbl' INTO TABLE SUPPLIER  FIELDS TERMINATED BY '|' ;
 select count(*) from SUPPLIER;
+select sum(S_ACCTBAL) from SUPPLIER;
 --enable_query_log
 
 #-- mark tables for RAPID
@@ -55,7 +56,13 @@ select * from SUPPLIER where S_NAME ='Supplier#000000005 ';
 
 explain select * from SUPPLIER where S_ACCTBAL = 5755.94;
 select * from SUPPLIER where S_ACCTBAL = 5755.94;
+
+explain format=tree select sum(S_ACCTBAL) from SUPPLIER;
 --enable_warnings
+
+set use_secondary_engine =forced;
+explain format=tree select sum(S_ACCTBAL) from SUPPLIER;
+select sum(S_ACCTBAL) from SUPPLIER;
 
 set global rapid_schema_embedding=OFF;
 drop database tpch_1024;

--- a/storage/rapid_engine/optimizer/optimizer.cpp
+++ b/storage/rapid_engine/optimizer/optimizer.cpp
@@ -188,13 +188,13 @@ bool Optimizer::translate_access_path(TranslateState *state, THD *thd, AccessPat
         table = path->table_scan().table;
         scan->scan_type = ScanTable::ScanType::FULL_TABLE_SCAN;
       }
-      assert(table);
+      ut_a(table);
 
       auto share = ShannonBase::shannon_loaded_tables->get(table->s->db.str, table->s->table_name.str);
       auto table_id = share ? share->m_tableid : 0;
       scan->rpd_table = (share->is_partitioned) ? Imcs::Imcs::instance()->get_rpd_parttable(table_id)
                                                 : Imcs::Imcs::instance()->get_rpd_table(table_id);
-      assert(scan->rpd_table);
+      ut_a(scan->rpd_table);
       scan->cost = path->cost();
       scan->estimated_rows = static_cast<ha_rows>(path->num_output_rows());
       scan->source_table = table;
@@ -754,7 +754,7 @@ std::unique_ptr<Imcs::Predicate> Optimizer::convert_item_to_predicate(const THD 
   if (lookup->key_parts == 1) {
     Item *item = lookup->items[0];
     if (!item) return nullptr;
-    assert(item->const_item());
+    ut_a(item->const_item());
 
     // Check if this key part has a guard condition
     if (lookup->cond_guards && lookup->cond_guards[0] && !(*lookup->cond_guards[0])) return nullptr;
@@ -1567,7 +1567,7 @@ bool Optimizer::decode_key_value(const uchar *key_ptr, const Field *field, Imcs:
  */
 Imcs::PredicateValue Optimizer::extract_value_from_item(const THD *thd, const Item *item, enum_field_types target_type,
                                                         const Field *target_field) {
-  if (!item->const_item()) assert(false);
+  if (!item->const_item()) ut_a(false);
   if (!item || target_type == MYSQL_TYPE_NULL) return Imcs::PredicateValue::null_value();
 
   if (target_type != MYSQL_TYPE_NULL && target_field) {
@@ -1622,7 +1622,7 @@ Imcs::PredicateValue Optimizer::extract_value_from_item(const THD *thd, const It
           if (dec) store_result = mutable_target_field->store_decimal(dec);
         } break;
         default:
-          assert(false);
+          ut_a(false);
           break;
       }
       if (store_result == TYPE_OK && !mutable_target_field->is_null()) {
@@ -1645,7 +1645,7 @@ Imcs::PredicateValue Optimizer::extract_value_from_item(const THD *thd, const It
   }
 
   // Handle constant folding if needed
-  if (!item->const_item()) assert(false);
+  if (!item->const_item()) ut_a(false);
 
   switch (item->type()) {
     case Item::INT_ITEM: {
@@ -1937,7 +1937,7 @@ AccessPath *Optimizer::OptimizeAndRewriteAccessPath(OptimizeContext *context, Ac
         rapid_path->aggregate().olap = path->aggregate().olap;
         rapid_path->has_group_skip_scan = path->has_group_skip_scan;
         rapid_path->set_num_output_rows(path->num_output_rows());
-        rapid_path->iterator = path->iterator;
+        rapid_path->iterator = nullptr;
       } else if (path->type == AccessPath::TEMPTABLE_AGGREGATE) {
         rapid_path->vectorized = context->can_vectorized;
         rapid_path->type = AccessPath::TEMPTABLE_AGGREGATE;

--- a/storage/rapid_engine/optimizer/rules/condition_pushdown.cpp
+++ b/storage/rapid_engine/optimizer/rules/condition_pushdown.cpp
@@ -665,21 +665,23 @@ Plan AggregationPushDown::handle_join_with_aggregation(Plan &join_node) {
  * 3. Must have significant data reduction potential
  */
 bool AggregationPushDown::can_apply_two_phase_aggregation(const LocalAgg *agg) {
-  // Check if all aggregate functions are decomposable
+  if (agg->children.empty()) return false;
+  const auto &child = agg->children[0];
+
+  // MUST be a Join child.
+  if (child->type() != PlanNode::Type::HASH_JOIN && child->type() != PlanNode::Type::NESTED_LOOP_JOIN) return false;
+
+  // All aggregate functions in this node must be decomposable.
   for (auto *agg_func : agg->aggregates) {
     if (!is_decomposable_aggregate(agg_func)) return false;
   }
 
-  // Estimate benefit: only worthwhile if we reduce data significantly
-  // Heuristic: input rows >> output rows (e.g., 100x reduction)
-  ha_rows input_rows = agg->children[0]->estimated_rows;
+  // Only worthwhile when the join output is significantly larger than the
+  // aggregation output (heuristic threshold: 10× row reduction).
+  ha_rows input_rows = child->estimated_rows;
   ha_rows output_rows = agg->estimated_rows;
-
   if (output_rows == 0) output_rows = 1;
-  double reduction_ratio = static_cast<double>(input_rows) / output_rows;
-
-  // Only apply if reduction is significant (at least 10x)
-  return reduction_ratio >= 10.0;
+  return (static_cast<double>(input_rows) / output_rows) >= 10.0;
 }
 
 /**
@@ -736,47 +738,51 @@ bool AggregationPushDown::is_decomposable_aggregate(const Item_func *agg_func) {
 Plan AggregationPushDown::create_two_phase_aggregation(Plan global_agg_node) {
   auto *global_agg = static_cast<LocalAgg *>(global_agg_node.get());
 
-  // Create local (partial) aggregation node
+  ut_a(!global_agg->children.empty());
+  ut_a(global_agg->children[0]->type() == PlanNode::Type::HASH_JOIN ||
+       global_agg->children[0]->type() == PlanNode::Type::NESTED_LOOP_JOIN);
+
   auto local_agg = std::make_unique<LocalAgg>();
-
-  // Copy GROUP BY columns (same for both phases)
   local_agg->group_by = global_agg->group_by;
+  local_agg->olap = global_agg->olap;
+  local_agg->is_global = false;  // local / partial phase
 
-  // Transform aggregate functions for local phase
+  // Build the local-phase aggregate list with cloned Item_sum objects so that the two nodes are fully independent.
   for (auto *global_func : global_agg->aggregates) {
     auto *sum_func = static_cast<Item_sum *>(global_func);
     switch (sum_func->sum_func()) {
       case Item_sum::SUM_FUNC:
       case Item_sum::MIN_FUNC:
       case Item_sum::MAX_FUNC:
-        // Direct mapping: local_sum -> global_sum
-        local_agg->aggregates.push_back(global_func);
-        break;
       case Item_sum::COUNT_FUNC:
-        // local_count -> global_sum(local_count)
-        local_agg->aggregates.push_back(global_func);
+      case Item_sum::AVG_FUNC: {
+        Item *copied = sum_func->copy_or_same(current_thd);
+        if (copied && copied != static_cast<Item *>(sum_func) && copied->type() == Item::SUM_FUNC_ITEM) {
+          local_agg->aggregates.push_back(static_cast<Item_func *>(copied));
+        } else {
+          // copy_or_same() returned `this` (window func path) or failed;
+          // skip local-phase entry for this function — correctness is
+          // preserved, just no partial aggregation benefit for it.
+        }
         break;
-      case Item_sum::AVG_FUNC:
-        // AVG needs decomposition into SUM and COUNT
-        // local: SUM(x) as partial_sum, COUNT(x) as partial_count
-        // global: SUM(partial_sum) / SUM(partial_count)
-        // For now, keep as-is (simplified - production code would transform)
-        local_agg->aggregates.push_back(global_func);
-        break;
+      }
       default:
-        // Non-decomposable - keep in global only
+        // Non-decomposable (STDDEV, VARIANCE, GROUP_CONCAT …):
+        // stays in global_agg only, no local counterpart.
         break;
     }
   }
 
-  // Connect: LocalAgg -> original child
-  local_agg->children.push_back(std::move(global_agg->children[0]));
-  // Estimate costs
+  // Wire: local_agg → original join child
   local_agg->estimated_rows = global_agg->estimated_rows;
-  local_agg->cost = local_agg->children[0]->cost * 1.5;  // Local agg overhead
-  // Connect: GlobalAgg -> LocalAgg
+  local_agg->cost = global_agg->children[0]->cost * 1.5;
+  local_agg->children.push_back(std::move(global_agg->children[0]));
+
+  // Wire: global_agg → local_agg
   global_agg->children[0] = std::move(local_agg);
-  global_agg->cost = global_agg->children[0]->cost * 1.2;  // Global agg overhead
+  global_agg->cost = global_agg->children[0]->cost * 1.2;
+  global_agg->is_global = true;
+
   return global_agg_node;
 }
 
@@ -847,30 +853,42 @@ Plan AggregationPushDown::try_push_below_join(Plan agg_node) {
 Plan AggregationPushDown::push_aggregation_to_join_side(Plan agg_node, Plan &join, bool push_to_left) {
   auto *agg = static_cast<LocalAgg *>(agg_node.get());
 
-  // Create new aggregation node for the join side
   auto side_agg = std::make_unique<LocalAgg>();
   side_agg->group_by = agg->group_by;
-  side_agg->aggregates = agg->aggregates;
   side_agg->order_by = agg->order_by;
+  side_agg->olap = agg->olap;
+  side_agg->is_global = false;
+
+  // Clone aggregate functions for the pushed-down side node.
+  for (auto *func : agg->aggregates) {
+    auto *sum_func = static_cast<Item_sum *>(func);
+    Item *copied = sum_func->copy_or_same(current_thd);
+    if (copied && copied != static_cast<Item *>(sum_func) && copied->type() == Item::SUM_FUNC_ITEM) {
+      side_agg->aggregates.push_back(static_cast<Item_func *>(copied));
+    }
+    // If copy_or_same() returns `this`, it means it's a window function or
+    // copy is unsupported — omit from pushed-down node; query remains correct.
+  }
 
   if (push_to_left) {
-    // Insert LocalAgg above left child
     side_agg->children.push_back(std::move(join->children[0]));
     side_agg->estimated_rows = agg->estimated_rows;
     side_agg->cost = side_agg->children[0]->cost * 1.5;
     join->children[0] = std::move(side_agg);
   } else {
-    // Insert LocalAgg above right child
     side_agg->children.push_back(std::move(join->children[1]));
     side_agg->estimated_rows = agg->estimated_rows;
     side_agg->cost = side_agg->children[0]->cost * 1.5;
     join->children[1] = std::move(side_agg);
   }
 
-  // Update join cost
   join->cost = join->children[0]->cost + join->children[1]->cost;
   join->estimated_rows = agg->estimated_rows;
-  // Remove the top-level aggregation and return just the join
+
+  // Explicitly release agg_node: its Item_func* ptrs have been cloned into
+  // side_agg; the original pointers remain valid in the arena but are no
+  // longer referenced by any plan node.
+  agg_node.reset();
   return std::move(join);
 }
 


### PR DESCRIPTION
can_apply_two_phase_aggregation() triggered two-phase wrapping for LocalAgg→Scan plans because it only checked the 10x row-reduction heuristic without verifying the child is a Join. For a Scan with high estimated_rows the ratio always exceeded the threshold, producing a redundant LocalAgg→LocalAgg→Scan topology.

Fix: guard can_apply_two_phase_aggregation() with an explicit HASH_JOIN/NESTED_LOOP_JOIN child-type check. Also replace the shallow Item_func* vector copy in create_two_phase_aggregation() and push_aggregation_to_join_side() with Item_sum::copy_or_same() to eliminate aliased aggregate state across two plan nodes.

Issues:#751

I hereby agree to the terms of the CLA available at: http://www.shannondata.ai/doc/cla/

## Summary

_Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR._

- Fixes #751 

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):