### PR TITLE
feat(trx):fix wrong trx state

### DIFF
--- a/storage/rapid_engine/handler/ha_shannon_rapid.cc
+++ b/storage/rapid_engine/handler/ha_shannon_rapid.cc
@@ -787,8 +787,8 @@ static void rapid_kill_connection(handlerton *hton, /*!< in:  innobase handlerto
                                                    killed */
   DBUG_TRACE;
   ut_a(hton == ShannonBase::shannon_rapid_hton_ptr);
-  trx_t *trx = thd_to_trx(thd);
 
+  trx_t *trx = thd_to_trx(thd);
   if (trx != nullptr) {
     /* Cancel a pending lock request if there are any */
     lock_cancel_if_waiting_and_release({trx});

--- a/storage/rapid_engine/imcs/imcu.h
+++ b/storage/rapid_engine/imcs/imcu.h
@@ -434,6 +434,10 @@ class Imcu : public MemoryObject {
    */
   void update_statistics() {}
 
+  inline void acquire_reader() { m_active_readers.fetch_add(1, std::memory_order_acq_rel); }
+  inline void release_reader() { m_active_readers.fetch_sub(1, std::memory_order_acq_rel); }
+  inline bool has_active_readers() const { return m_active_readers.load(std::memory_order_acquire) > 0; }
+
  private:
   /**
   Imcu::scan_range - Scan a specified range within the IMCU
@@ -539,6 +543,8 @@ class Imcu : public MemoryObject {
 
   // Optimistic concurrency version counter
   std::atomic<uint64> m_version{0};
+
+  alignas(64) std::atomic<uint32_t> m_active_readers{0};
 
   // Back Reference
   RpdTable *m_owner_table;

--- a/storage/rapid_engine/imcs/table.cpp
+++ b/storage/rapid_engine/imcs/table.cpp
@@ -125,7 +125,7 @@ Table::Table(const TABLE *&mysql_table, const TableConfig &config) : RpdTable(my
 }
 
 Table::~Table() {
-  std::scoped_lock lk(m_imcu_mtex);
+  std::scoped_lock lk(m_table_mutex);
   m_imcus.clear();
   m_imcu_index.clear();
   if (m_memory_pool) m_memory_pool.reset();
@@ -264,11 +264,7 @@ int Table::create_index_memo(const Rapid_load_context *context) {
   return ShannonBase::SHANNON_SUCCESS;
 }
 
-int Table::register_transaction(Transaction *trx) {
-  assert(trx);
-  for (auto &imcu : m_imcus) trx->register_imcu_modification(imcu);
-  return ShannonBase::SHANNON_SUCCESS;
-}
+int Table::register_transaction(Transaction *trx) { return ShannonBase::SHANNON_SUCCESS; }
 
 row_id_t Table::insert_row(const Rapid_load_context *context, uchar *rowdata) {
   SHANNON_THREAD_LOCAL RowBuffer row_data(m_metadata.num_columns);
@@ -417,7 +413,7 @@ size_t Table::compact(double delete_ratio_threshold) {
   size_t total_physically_removed = 0;
   std::vector<std::shared_ptr<Imcu>> new_imcus;
   {
-    std::unique_lock lock(m_imcu_mtex);
+    std::unique_lock lock(m_table_mutex);
     new_imcus.reserve(m_imcus.size());
     for (auto &imcu : m_imcus) {
       if (imcu->needs_compaction() && imcu->get_delete_ratio() >= delete_ratio_threshold) {

--- a/storage/rapid_engine/imcs/table.h
+++ b/storage/rapid_engine/imcs/table.h
@@ -197,6 +197,8 @@ class RpdTable : public MemoryObject {
    */
   virtual Imcu *locate_imcu(size_t imcu_id) = 0;
 
+  virtual std::vector<std::shared_ptr<Imcu>> get_imcus() const = 0;
+
   /** @brief Lookup index by key name. */
   virtual Index::Index<uchar, row_id_t> *get_index(std::string key_name) = 0;
 
@@ -231,7 +233,6 @@ class RpdTable : public MemoryObject {
   TableMetadata m_metadata;
 
   // IMCU list (supports dynamic expansion)
-  std::mutex m_imcu_mtex;
   std::vector<std::shared_ptr<Imcu>> m_imcus;
 
   // IMCU index (fast positioning)
@@ -307,6 +308,11 @@ class Table : public RpdTable {
     // size_t imcu_idx = global_row_id / m_metadata.rows_per_imcu;
     if (imcu_id >= m_imcus.size()) return nullptr;
     return m_imcus[imcu_id].get();
+  }
+
+  std::vector<std::shared_ptr<Imcu>> get_imcus() const override {
+    std::shared_lock read_lock(m_table_mutex);
+    return m_imcus;
   }
 
   virtual row_id_t rows(const Rapid_context *) final { return m_metadata.total_rows; }
@@ -493,6 +499,16 @@ class PartTable : public Table {
   inline RpdTable *get_partition(std::string part_key) {
     if (m_partitions.find(part_key) == m_partitions.end()) return nullptr;
     return m_partitions[part_key].get();
+  }
+
+  std::vector<std::shared_ptr<Imcu>> get_imcus() const override {
+    std::vector<std::shared_ptr<Imcu>> all;
+    for (const auto &[_, table_ptr] : m_partitions) {
+      if (!table_ptr) continue;
+      auto sub = table_ptr->get_imcus();
+      all.insert(all.end(), sub.begin(), sub.end());
+    }
+    return all;
   }
 
  private:

--- a/storage/rapid_engine/imcs/table0view.cpp
+++ b/storage/rapid_engine/imcs/table0view.cpp
@@ -75,11 +75,14 @@ int RapidCursor::init() {
   m_scan_context->m_trx = ShannonBase::Transaction::get_or_create_trx(current_thd);
   m_scan_context->m_trx->begin();
   m_scan_context->m_extra_info.m_trxid = m_scan_context->m_trx->get_id();
-  m_scan_context->m_extra_info.m_scn = TransactionCoordinator::instance().get_current_scn();
 
   if (!m_scan_context->m_trx->is_active())
     m_scan_context->m_trx->begin(ShannonBase::Transaction::get_rpd_isolation_level(current_thd));
-  m_rpd_table->register_transaction(m_scan_context->m_trx);
+
+  m_scan_context->m_extra_info.m_scn = TransactionCoordinator::instance().get_current_scn();
+
+  switch_scan_imcus(m_rpd_table);
+
   m_scan_context->m_trx->acquire_snapshot();
 
   m_scan_context->m_schema_name = const_cast<char *>(m_data_source->s->db.str);
@@ -87,7 +90,6 @@ int RapidCursor::init() {
   m_scan_context->limit = 0;
   m_scan_context->rows_returned = 0;
 
-  // Build columnar chunk buffers based on the current read_set
   init_col_chunks();
 
   m_scan_state.reset();
@@ -108,8 +110,15 @@ int RapidCursor::init() {
 }
 
 int RapidCursor::end() {
+  if (!m_inited.load(std::memory_order_acquire)) return ShannonBase::SHANNON_SUCCESS;
+
   m_scan_context->m_trx->release_snapshot();
   m_scan_context->m_trx->commit();
+
+  for (auto &imcu : m_scan_imcus) {
+    if (imcu) imcu->release_reader();
+  }
+  m_scan_imcus.clear();
 
   m_scan_state.reset();
   m_rows_skipped = 0;
@@ -118,6 +127,30 @@ int RapidCursor::end() {
 
   m_inited.store(false, std::memory_order_release);
   return ShannonBase::SHANNON_SUCCESS;
+}
+
+void RapidCursor::switch_scan_imcus(RpdTable *new_table) {
+  for (auto &imcu : m_scan_imcus) {
+    if (imcu) imcu->release_reader();
+  }
+  m_scan_imcus.clear();
+
+  m_rpd_table = new_table;
+  if (m_rpd_table) {
+    m_scan_imcus = m_rpd_table->get_imcus();  // copy the snapshot of imcus for scan.
+    for (auto &imcu : m_scan_imcus) {
+      if (imcu) imcu->acquire_reader();
+    }
+  }
+}
+
+void RapidCursor::active_table(RpdTable *rpd_table) {
+  // partition table scenario: the same cursor instance directly switches the underlying partition table without going
+  // through init()/end(). Must go through the same switch_scan_imcus() entry, otherwise the reference count of the old
+  // partition will never be released, and the new partition will not have any reference count protection, compaction
+  // may conflict with the IMCU of the new partition that is being scanned.
+  switch_scan_imcus(rpd_table);
+  m_scan_state.reset();
 }
 
 void RapidCursor::init_col_chunks() {

--- a/storage/rapid_engine/imcs/table0view.h
+++ b/storage/rapid_engine/imcs/table0view.h
@@ -48,6 +48,7 @@ class Rapid_scan_context;
 namespace Imcs {
 class Imcs;
 class Cu;
+class Imcu;
 class RapidTable;
 class RpdTable;
 class RowBuffer;
@@ -147,10 +148,7 @@ class RapidCursor : public MemoryObject {
   inline RpdTable *table_source() const { return m_src_rpd_table; }
 
   // to reset to a new rpd table source. Used in Partition Table case.
-  inline void active_table(RpdTable *rpd_table) {
-    m_rpd_table = rpd_table;
-    m_scan_state.reset();
-  }
+  void active_table(RpdTable *rpd_table);
 
   inline TABLE *source() const { return m_data_source; }
 
@@ -230,12 +228,14 @@ class RapidCursor : public MemoryObject {
 
   template <typename Reciever>
   size_t scan_batch_internal(size_t batch_size, const std::vector<uint32_t> &projection_cols, Reciever &sink);
+  void switch_scan_imcus(RpdTable *new_table);
 
  private:
   std::atomic<bool> m_inited{false};
   TABLE *m_data_source{nullptr};
   RpdTable *m_rpd_table{nullptr};      ///< active partition (or full table)
   RpdTable *m_src_rpd_table{nullptr};  ///< root/parent table
+  std::vector<std::shared_ptr<Imcu>> m_scan_imcus;
 
   std::unique_ptr<Rapid_scan_context> m_scan_context{nullptr};
 

--- a/storage/rapid_engine/imcs/worker.cpp
+++ b/storage/rapid_engine/imcs/worker.cpp
@@ -61,21 +61,23 @@ void BkgWorkerPool::auto_maintenance_thread() {
       m_auto_cv.wait_for(lock, std::chrono::seconds(ShannonBase::shannon_rpd_engine_cfg.gc_interval_seconds),
                          []() { return !m_auto_thread_running.load(std::memory_order_acquire); });
     }
-
     if (!m_auto_thread_running.load(std::memory_order_acquire)) break;
 
     auto pool = BkgWorkerPool::try_instance();
     if (!pool || BkgWorkerPool::is_shutdown()) break;
 
     auto imcs = ShannonBase::Imcs::Imcs::instance();
-    // 1. auto GC
+
+    // 1. auto GC —— gc_interval_scn is the minimum interval between two consecutive GC operations, but the real safe
+    // SCN is determined by the actual active transactions.
     uint64_t current_scn = TransactionCoordinator::instance().get_current_scn();
     uint64_t last = m_last_gc_scn.load(std::memory_order_acquire);
     if (current_scn > last && current_scn - last >= ShannonBase::shannon_rpd_engine_cfg.gc_interval_scn) {
+      uint64_t safe_scn = TransactionCoordinator::instance().get_gc_safe_scn();
+
       imcs->for_each_table([&](RpdTable *table) {
         if (m_auto_thread_running.load(std::memory_order_acquire)) {
-          uint64_t min_active_scn = current_scn - ShannonBase::shannon_rpd_engine_cfg.gc_interval_scn;
-          pool->schedule_gc(table, min_active_scn);
+          pool->schedule_gc(table, safe_scn);
         }
       });
       m_last_gc_scn.store(current_scn, std::memory_order_release);
@@ -83,11 +85,12 @@ void BkgWorkerPool::auto_maintenance_thread() {
 
     if (!m_auto_thread_running.load(std::memory_order_acquire)) break;
 
-    // 2. auto compaction
+    // 2. auto compaction —— to increase ref cnt sothat the imcu being scanned by RapidCursor will not be compacted
+    // concurrently.
     imcs->for_each_table([&](RpdTable *table) {
       if (!m_auto_thread_running.load(std::memory_order_acquire)) return;
       table->foreach_imcu([&](Imcu *imcu) {
-        if (!imcu || !imcu->needs_compaction()) return;
+        if (!imcu || imcu->has_active_readers() || !imcu->needs_compaction()) return;
         if (m_auto_thread_running.load(std::memory_order_acquire)) {
           pool->schedule_compact(table, imcu);
         }
@@ -96,7 +99,7 @@ void BkgWorkerPool::auto_maintenance_thread() {
 
     if (!m_auto_thread_running.load(std::memory_order_acquire)) break;
 
-    // 3. stats update - 10 mins interval
+    // 3. stats update
     static auto last_stats_time = std::chrono::steady_clock::now();
     auto now = std::chrono::steady_clock::now();
     if (std::chrono::duration_cast<std::chrono::minutes>(now - last_stats_time).count() >= 10) {

--- a/storage/rapid_engine/trx/transaction.cpp
+++ b/storage/rapid_engine/trx/transaction.cpp
@@ -99,20 +99,45 @@ Transaction::Transaction(THD *thd) : m_thd(thd) {
 
 Transaction::~Transaction() {
   release_snapshot();
+  sync_coordinator_state(CoordState::FINALIZING);
 
-  if (trx_is_started(m_trx_impl)) trx_rollback_for_mysql(m_trx_impl);
-
-  if (m_registered_in_coordinator) {
+  if (trx_is_started(m_trx_impl)) {
+    if (m_coord_state == CoordState::ACTIVE) {
+      TransactionCoordinator::instance().rollback_transaction(this);
+      m_coord_state = CoordState::UNREGISTERED;
+    }
+    trx_rollback_for_mysql(m_trx_impl);
+  } else if (m_coord_state == CoordState::ACTIVE) {
     TransactionCoordinator::instance().unregister_transaction(this);
-    m_registered_in_coordinator = false;
+    m_coord_state = CoordState::UNREGISTERED;
   }
 
-  m_registered_in_coordinator = false;
   m_start_scn = 0;
   m_commit_scn = 0;
   m_stmt_active = false;
-
   trx_free_for_mysql(m_trx_impl);
+}
+
+void Transaction::sync_coordinator_state(CoordState intent) {
+  if (m_coord_state == CoordState::ACTIVE &&
+      m_trx_impl->state.load(std::memory_order_acquire) == TRX_STATE_NOT_STARTED) {
+    TransactionCoordinator::instance().unregister_transaction(this);
+    m_coord_state = CoordState::UNREGISTERED;
+    m_start_scn = 0;
+    m_commit_scn = 0;
+  }
+
+  switch (intent) {
+    case CoordState::ACTIVE:
+      if (m_coord_state == CoordState::UNREGISTERED) {
+        m_start_scn = TransactionCoordinator::instance().register_transaction(this, m_iso_level);
+        m_coord_state = CoordState::ACTIVE;
+      }
+      break;
+    case CoordState::UNREGISTERED:
+    case CoordState::FINALIZING:
+      break;
+  }
 }
 
 Transaction::ISOLATION_LEVEL Transaction::get_rpd_isolation_level(THD *thd) {
@@ -157,24 +182,15 @@ int Transaction::begin(ISOLATION_LEVEL iso_level) {
   }
 
   ut_a(m_trx_impl);
-  // Check: If the transaction is registered but the underlying transaction has ended, it needs to be unregistered
-  // first.
-  if (m_registered_in_coordinator && m_trx_impl->state.load() == TRX_STATE_NOT_STARTED) {
-    // This situation indicates that the state was not properly reset after the last commit/rollback, so the old
-    // registration should be proactively unregistered.
-    TransactionCoordinator::instance().unregister_transaction(this);
-    m_registered_in_coordinator = false;
-    m_start_scn = 0;
-    m_commit_scn = 0;
-  }
+  sync_coordinator_state(CoordState::ACTIVE);
 
   m_trx_impl->isolation_level = is;
 
   trx_start_if_not_started(m_trx_impl, !m_read_only, UT_LOCATION_HERE);
 
-  if (!m_registered_in_coordinator) {
+  if (m_coord_state == CoordState::UNREGISTERED) {
     m_start_scn = TransactionCoordinator::instance().register_transaction(this, iso_level);
-    m_registered_in_coordinator = true;
+    m_coord_state = CoordState::ACTIVE;
   }
   return SHANNON_SUCCESS;
 }
@@ -199,37 +215,37 @@ int Transaction::begin_stmt(ISOLATION_LEVEL iso_level) {
 }
 
 int Transaction::commit() {
-  dberr_t error = DB_SUCCESS;
+  sync_coordinator_state(CoordState::FINALIZING);
 
+  dberr_t error = DB_SUCCESS;
   if (trx_is_started(m_trx_impl)) error = trx_commit_for_mysql(m_trx_impl);
 
   if (error != DB_SUCCESS) {
-    if (m_registered_in_coordinator) {
+    if (m_coord_state == CoordState::ACTIVE) {
       TransactionCoordinator::instance().rollback_transaction(this);
-      m_registered_in_coordinator = false;
-      m_start_scn = 0;
-      m_commit_scn = 0;
     }
+    m_coord_state = CoordState::UNREGISTERED;
+    m_start_scn = 0;
+    m_commit_scn = 0;
     m_stmt_active = false;
     return HA_ERR_GENERIC;
   }
 
-  if (m_registered_in_coordinator) {
-    TransactionCoordinator::instance().commit_transaction(this);
-    m_registered_in_coordinator = false;
-    m_start_scn = 0;
-  }
+  if (m_coord_state == CoordState::ACTIVE) TransactionCoordinator::instance().commit_transaction(this);
 
+  m_coord_state = CoordState::UNREGISTERED;
+  m_start_scn = 0;
   m_stmt_active = false;
   return SHANNON_SUCCESS;
 }
 
 int Transaction::rollback() {
-  dberr_t error = DB_SUCCESS;
+  sync_coordinator_state(CoordState::FINALIZING);
 
-  if (m_registered_in_coordinator) {
+  dberr_t error = DB_SUCCESS;
+  if (m_coord_state == CoordState::ACTIVE) {
     TransactionCoordinator::instance().rollback_transaction(this);
-    m_registered_in_coordinator = false;
+    m_coord_state = CoordState::UNREGISTERED;
     m_start_scn = 0;
     m_commit_scn = 0;
   }
@@ -237,9 +253,7 @@ int Transaction::rollback() {
   if (trx_is_started(m_trx_impl)) {
     error = trx_rollback_for_mysql(m_trx_impl);
   }
-
   m_stmt_active = false;
-
   return (error != DB_SUCCESS) ? HA_ERR_GENERIC : SHANNON_SUCCESS;
 }
 
@@ -279,11 +293,12 @@ bool Transaction::changes_visible(Transaction::ID trx_id, const char *table_name
 }
 
 void Transaction::register_imcu_modification(std::shared_ptr<ShannonBase::Imcs::Imcu> imcu) {
-  if (m_registered_in_coordinator) TransactionCoordinator::instance().register_imcu_modification(get_id(), imcu);
+  if (m_coord_state == CoordState::ACTIVE)
+    TransactionCoordinator::instance().register_imcu_modification(get_id(), imcu);
 }
 
 uint64_t TransactionCoordinator::register_transaction(Transaction *trx, Transaction::ISOLATION_LEVEL iso_level) {
-  assert(trx != nullptr);
+  ut_a(trx != nullptr);
   // Lazy-start the worker thread on first write transaction: Start batch worker on first write txn, not at construction
   if (!trx->m_read_only) {
     bool expected = false;
@@ -310,25 +325,38 @@ uint64_t TransactionCoordinator::register_transaction(Transaction *trx, Transact
 }
 
 bool TransactionCoordinator::commit_transaction(Transaction *trx) {
-  assert(trx != nullptr);
+  ut_a(trx != nullptr);
 
-  ut_a(trx->m_trx_impl != nullptr);
-
-  uint64_t commit_scn;
-  if (!trx->m_read_only && trx->m_trx_impl->no != TRX_ID_MAX) {
-    commit_scn = static_cast<uint64_t>(trx->m_trx_impl->no);
-  } else {
-    ib::warn() << "Rapid: commit_transaction() invoked for a transaction "
-                  "without a valid InnoDB serialisation number (read_only="
-               << trx->m_read_only << "); falling back to internal counter.";
-    commit_scn = Transaction::VersionManager::instance().allocate_scn();
+  {
+    std::shared_lock<std::shared_mutex> lock(m_txns_mutex);
+    auto it = m_active_txns.find(trx->get_id());
+    if (it == m_active_txns.end()) return false;
+    if (it->second.modified_imcus.empty()) {
+      lock.unlock();
+      std::unique_lock<std::shared_mutex> wlock(m_txns_mutex);
+      m_active_txns.erase(trx->get_id());
+      update_min_active_scn();
+      return true;
+    }
   }
 
+  ut_ad(trx->m_trx_impl != nullptr && trx->m_trx_impl->no != TRX_ID_MAX);
+  uint64_t commit_scn;
+  if (trx->m_trx_impl != nullptr && trx->m_trx_impl->no != TRX_ID_MAX) {
+    commit_scn = static_cast<uint64_t>(trx->m_trx_impl->no);
+  } else {
+    ib::warn() << "Rapid: commit_transaction() derived commit_scn from fallback "
+                  "counter instead of trx->no (txn_id="
+               << trx->get_id() << ", read_only=" << trx->m_read_only
+               << ") — modified_imcus non-empty but trx->no invalid, "
+                  "this should not happen on the normal write commit path.";
+    commit_scn = Transaction::VersionManager::instance().allocate_scn();
+  }
   return commit_transaction(trx, commit_scn);
 }
 
 bool TransactionCoordinator::commit_transaction(Transaction *trx, uint64_t commit_scn) {
-  assert(trx != nullptr);
+  ut_a(trx != nullptr);
 
   bool ok = commit_transaction_internal(trx, commit_scn);
   if (!ok) return false;
@@ -341,10 +369,23 @@ bool TransactionCoordinator::commit_transaction(Transaction *trx, uint64_t commi
 }
 
 bool TransactionCoordinator::commit_transaction_internal(Transaction *trx, uint64_t commit_scn) {
-  assert(trx != nullptr);
-
+  ut_a(trx != nullptr);
   Transaction::ID txn_id = trx->get_id();
+
   std::vector<std::shared_ptr<ShannonBase::Imcs::Imcu>> imcus_to_commit;
+  {
+    std::shared_lock<std::shared_mutex> lock(m_txns_mutex);
+    auto it = m_active_txns.find(txn_id);
+    if (it == m_active_txns.end()) return false;
+    imcus_to_commit = it->second.modified_imcus;
+  }
+
+  for (auto &imcu : imcus_to_commit) {
+    if (!imcu) continue;
+    auto journal = imcu->get_transaction_journal();
+    if (journal) journal->commit_transaction(txn_id, commit_scn);
+  }
+
   {
     std::unique_lock<std::shared_mutex> lock(m_txns_mutex);
     auto it = m_active_txns.find(txn_id);
@@ -353,18 +394,8 @@ bool TransactionCoordinator::commit_transaction_internal(Transaction *trx, uint6
     it->second.commit_scn = commit_scn;
     it->second.status = TransactionInfo::COMMITTED;
     trx->m_commit_scn = commit_scn;
-
-    ut_ad(trx->m_commit_scn == it->second.commit_scn);
-
-    imcus_to_commit = it->second.modified_imcus;
     m_active_txns.erase(it);
     update_min_active_scn();
-  }
-
-  for (auto &imcu : imcus_to_commit) {
-    if (imcu == nullptr) continue;
-    auto journal = imcu->get_transaction_journal();
-    if (journal) journal->commit_transaction(txn_id, commit_scn);
   }
 
   for (auto &imcu : imcus_to_commit) {
@@ -374,7 +405,7 @@ bool TransactionCoordinator::commit_transaction_internal(Transaction *trx, uint6
 }
 
 bool TransactionCoordinator::rollback_transaction(Transaction *trx) {
-  assert(trx != nullptr);
+  ut_a(trx != nullptr);
   Transaction::ID txn_id = trx->get_id();
 
   std::vector<std::shared_ptr<ShannonBase::Imcs::Imcu>> imcus_to_rollback;
@@ -402,7 +433,7 @@ bool TransactionCoordinator::rollback_transaction(Transaction *trx) {
 }
 
 void TransactionCoordinator::unregister_transaction(Transaction *trx) {
-  assert(trx != nullptr);
+  ut_a(trx != nullptr);
 
   Transaction::ID txn_id = trx->get_id();
   std::unique_lock lock(m_txns_mutex);

--- a/storage/rapid_engine/trx/transaction.h
+++ b/storage/rapid_engine/trx/transaction.h
@@ -53,6 +53,8 @@ class Transaction : public MemoryObject {
   using ID = uint64_t;
   static constexpr ID MAX_ID = std::numeric_limits<uint64_t>::max();
 
+  enum class CoordState : uint8_t { UNREGISTERED, ACTIVE, FINALIZING };
+
   class VersionManager {
    public:
     // Snapshot structure
@@ -225,12 +227,15 @@ class Transaction : public MemoryObject {
   virtual bool is_active() { return trx_is_started(m_trx_impl); }
 
   void register_imcu_modification(std::shared_ptr<ShannonBase::Imcs::Imcu> imcu);
+  void reconcile_on_external_abort() { sync_coordinator_state(CoordState::FINALIZING); }
 
   uint64_t get_start_scn() const { return m_start_scn; }
   uint64_t get_commit_scn() const { return m_commit_scn; }
 
  private:
   friend class TransactionCoordinator;
+  void sync_coordinator_state(CoordState intent);
+  CoordState m_coord_state{CoordState::UNREGISTERED};
 
   THD *m_thd{nullptr};
 
@@ -244,8 +249,6 @@ class Transaction : public MemoryObject {
 
   uint64_t m_start_scn{0};
   uint64_t m_commit_scn{0};
-
-  bool m_registered_in_coordinator{false};
 };
 
 class TransactionCoordinator {
@@ -341,6 +344,8 @@ class TransactionCoordinator {
   inline uint64_t allocate_scn() { return Transaction::VersionManager::instance().allocate_scn(); }
 
   inline uint64_t get_min_active_scn() const { return Transaction::VersionManager::instance().get_min_active_scn(); }
+
+  inline uint64_t get_gc_safe_scn() const { return get_min_active_scn(); }
 
   inline uint64_t get_gc_watermark(uint64_t safety_margin = 1000) const {
     return Transaction::VersionManager::instance().get_gc_watermark(safety_margin);


### PR DESCRIPTION
ShannonBase::Transaction wraps an InnoDB trx_t* (m_trx_impl) rather than implementing its own transaction object (see the note at the top of transaction.cpp: "we use innodb trx as rapid's... in future we will impl our own trx implementation"). On top of this, Rapid maintains a second, independent bookkeeping layer — TransactionCoordinator::m_active_txns plus per-IMCU TransactionJournal version chains — used purely for IMCS/columnar MVCC visibility. These two layers (InnoDB's trx_t state machine and Rapid's coordinator registration) were being kept in sync by a single unguarded bool m_registered_in_coordinator flag and ad-hoc, duplicated if checks scattered across begin(), commit(), rollback(), and ~Transaction().

Issues:#772

I hereby agree to the terms of the CLA available at: http://www.shannondata.ai/doc/cla/

## Summary

_Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR._

- Fixes #772

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):