### PR TITLE
feat(perf):push down limit-offset to table scan

### DIFF
--- a/mysql-test/suite/secondary_engine/r/shannon_limit_pushdown.result
+++ b/mysql-test/suite/secondary_engine/r/shannon_limit_pushdown.result
@@ -1,0 +1,130 @@
+CREATE DATABASE rapid_limit_pushdown;
+USE rapid_limit_pushdown;
+CREATE TABLE t_limit (
+id INT PRIMARY KEY,
+grp INT NOT NULL,
+payload VARCHAR(32) NOT NULL
+) SECONDARY_ENGINE=rapid;
+ALTER TABLE t_limit SECONDARY_LOAD;
+SET USE_SECONDARY_ENGINE=FORCED;
+SET secondary_engine_cost_threshold=0;
+SET SESSION optimizer_switch='hypergraph_optimizer=on';
+Warnings:
+Warning	1287	The hypergraph optimizer is highly experimental and is meant for testing only. Do not enable it unless you are a MySQL developer.
+# optimizer=hypergraph
+EXPLAIN FORMAT=TREE SELECT * FROM t_limit LIMIT 5;
+EXPLAIN
+-> Vectorized table scan on t_limit in secondary engine Rapid [limit: 5]
+
+Warnings:
+Note	1003	Query is executed in secondary engine; the actual query plan may diverge from the printed one
+SELECT COUNT(*) AS rows_returned FROM (SELECT * FROM t_limit LIMIT 5) d;
+rows_returned
+5
+EXPLAIN FORMAT=TREE SELECT * FROM t_limit LIMIT 5 OFFSET 7;
+EXPLAIN
+-> Vectorized table scan on t_limit in secondary engine Rapid [limit: 5] [offset: 7]
+
+Warnings:
+Note	1003	Query is executed in secondary engine; the actual query plan may diverge from the printed one
+SELECT COUNT(*) AS rows_returned FROM (SELECT * FROM t_limit LIMIT 5 OFFSET 7) d;
+rows_returned
+5
+EXPLAIN FORMAT=TREE SELECT * FROM t_limit WHERE grp = 1 LIMIT 5;
+EXPLAIN
+-> Vectorized table scan on t_limit in secondary engine Rapid [filter: (t_limit.grp = 1)] [limit: 5]
+
+Warnings:
+Note	1003	Query is executed in secondary engine; the actual query plan may diverge from the printed one
+SELECT COUNT(*) AS rows_returned FROM (SELECT * FROM t_limit WHERE grp = 1 LIMIT 5) d;
+rows_returned
+5
+EXPLAIN FORMAT=TREE SELECT * FROM t_limit ORDER BY payload LIMIT 5;
+EXPLAIN
+-> Sort: t_limit.payload, limit input to 5 row(s) per chunk
+    -> Vectorized table scan on t_limit in secondary engine Rapid
+
+Warnings:
+Note	1003	Query is executed in secondary engine; the actual query plan may diverge from the printed one
+SELECT id FROM t_limit ORDER BY payload LIMIT 5;
+id
+1
+10
+100
+101
+102
+EXPLAIN FORMAT=TREE SELECT * FROM t_limit ORDER BY id LIMIT 5;
+EXPLAIN
+-> Limit: 5 row(s)
+    -> Vectorized table scan on t_limit in secondary engine Rapid
+
+Warnings:
+Note	1003	Query is executed in secondary engine; the actual query plan may diverge from the printed one
+SELECT id FROM t_limit ORDER BY id LIMIT 5;
+id
+1
+2
+3
+4
+5
+SET SESSION optimizer_switch='hypergraph_optimizer=off';
+# optimizer=legacy
+EXPLAIN FORMAT=TREE SELECT * FROM t_limit LIMIT 5;
+EXPLAIN
+-> Vectorized table scan on t_limit in secondary engine Rapid [limit: 5]
+
+Warnings:
+Note	1003	Query is executed in secondary engine; the actual query plan may diverge from the printed one
+SELECT COUNT(*) AS rows_returned FROM (SELECT * FROM t_limit LIMIT 5) d;
+rows_returned
+5
+EXPLAIN FORMAT=TREE SELECT * FROM t_limit LIMIT 5 OFFSET 7;
+EXPLAIN
+-> Vectorized table scan on t_limit in secondary engine Rapid [limit: 5] [offset: 7]
+
+Warnings:
+Note	1003	Query is executed in secondary engine; the actual query plan may diverge from the printed one
+SELECT COUNT(*) AS rows_returned FROM (SELECT * FROM t_limit LIMIT 5 OFFSET 7) d;
+rows_returned
+5
+EXPLAIN FORMAT=TREE SELECT * FROM t_limit WHERE grp = 1 LIMIT 5;
+EXPLAIN
+-> Vectorized table scan on t_limit in secondary engine Rapid [filter: (t_limit.grp = 1)] [limit: 5]
+
+Warnings:
+Note	1003	Query is executed in secondary engine; the actual query plan may diverge from the printed one
+SELECT COUNT(*) AS rows_returned FROM (SELECT * FROM t_limit WHERE grp = 1 LIMIT 5) d;
+rows_returned
+5
+EXPLAIN FORMAT=TREE SELECT * FROM t_limit ORDER BY payload LIMIT 5;
+EXPLAIN
+-> Limit: 5 row(s)
+    -> Sort: t_limit.payload, limit input to 5 row(s) per chunk
+        -> Vectorized table scan on t_limit in secondary engine Rapid
+
+Warnings:
+Note	1003	Query is executed in secondary engine; the actual query plan may diverge from the printed one
+SELECT id FROM t_limit ORDER BY payload LIMIT 5;
+id
+1
+10
+100
+101
+102
+EXPLAIN FORMAT=TREE SELECT * FROM t_limit ORDER BY id LIMIT 5;
+EXPLAIN
+-> Limit: 5 row(s)
+    -> Sort: t_limit.id, limit input to 5 row(s) per chunk
+        -> Vectorized table scan on t_limit in secondary engine Rapid
+
+Warnings:
+Note	1003	Query is executed in secondary engine; the actual query plan may diverge from the printed one
+SELECT id FROM t_limit ORDER BY id LIMIT 5;
+id
+1
+2
+3
+4
+5
+DROP TABLE t_limit;
+DROP DATABASE rapid_limit_pushdown;

--- a/mysql-test/suite/secondary_engine/t/shannon_limit_pushdown.test
+++ b/mysql-test/suite/secondary_engine/t/shannon_limit_pushdown.test
@@ -1,0 +1,71 @@
+# Rapid single-table LIMIT/OFFSET pushdown and ordering safety.
+
+# Some developer builds do not install the optional embedding model used by
+# query arbitration. It is unrelated to LIMIT execution and is already
+# reported to the client, so do not let that environmental message fail MTR.
+--disable_query_log
+CALL mtr.add_suppression("ML operation failed. cannot find ONNX model for: multilingual-e5-small");
+--enable_query_log
+
+CREATE DATABASE rapid_limit_pushdown;
+USE rapid_limit_pushdown;
+
+--disable_warnings
+CREATE TABLE t_limit (
+  id INT PRIMARY KEY,
+  grp INT NOT NULL,
+  payload VARCHAR(32) NOT NULL
+) SECONDARY_ENGINE=rapid;
+--enable_warnings
+
+--disable_query_log
+let $i = 1;
+while ($i <= 256) {
+  --eval INSERT INTO t_limit VALUES ($i, MOD($i, 4), CONCAT('row-', $i))
+  inc $i;
+}
+--enable_query_log
+
+ALTER TABLE t_limit SECONDARY_LOAD;
+SET USE_SECONDARY_ENGINE=FORCED;
+SET secondary_engine_cost_threshold=0;
+
+# Run the same safety checks through both optimizer front ends.
+SET SESSION optimizer_switch='hypergraph_optimizer=on';
+--echo # optimizer=hypergraph
+
+# A plain LIMIT and OFFSET are absorbed by the Rapid scan.
+EXPLAIN FORMAT=TREE SELECT * FROM t_limit LIMIT 5;
+SELECT COUNT(*) AS rows_returned FROM (SELECT * FROM t_limit LIMIT 5) d;
+EXPLAIN FORMAT=TREE SELECT * FROM t_limit LIMIT 5 OFFSET 7;
+SELECT COUNT(*) AS rows_returned FROM (SELECT * FROM t_limit LIMIT 5 OFFSET 7) d;
+
+# A pushed storage predicate may share the scan limit.
+EXPLAIN FORMAT=TREE SELECT * FROM t_limit WHERE grp = 1 LIMIT 5;
+SELECT COUNT(*) AS rows_returned FROM (SELECT * FROM t_limit WHERE grp = 1 LIMIT 5) d;
+
+# ORDER BY is a barrier: never cap an unordered scan before Top-N/filesort.
+EXPLAIN FORMAT=TREE SELECT * FROM t_limit ORDER BY payload LIMIT 5;
+SELECT id FROM t_limit ORDER BY payload LIMIT 5;
+
+# Under forced secondary execution, retain the Rapid vectorized-scan shape.
+# LIMIT stays above the scan and must not become a pushed scan limit.
+EXPLAIN FORMAT=TREE SELECT * FROM t_limit ORDER BY id LIMIT 5;
+SELECT id FROM t_limit ORDER BY id LIMIT 5;
+
+SET SESSION optimizer_switch='hypergraph_optimizer=off';
+--echo # optimizer=legacy
+
+EXPLAIN FORMAT=TREE SELECT * FROM t_limit LIMIT 5;
+SELECT COUNT(*) AS rows_returned FROM (SELECT * FROM t_limit LIMIT 5) d;
+EXPLAIN FORMAT=TREE SELECT * FROM t_limit LIMIT 5 OFFSET 7;
+SELECT COUNT(*) AS rows_returned FROM (SELECT * FROM t_limit LIMIT 5 OFFSET 7) d;
+EXPLAIN FORMAT=TREE SELECT * FROM t_limit WHERE grp = 1 LIMIT 5;
+SELECT COUNT(*) AS rows_returned FROM (SELECT * FROM t_limit WHERE grp = 1 LIMIT 5) d;
+EXPLAIN FORMAT=TREE SELECT * FROM t_limit ORDER BY payload LIMIT 5;
+SELECT id FROM t_limit ORDER BY payload LIMIT 5;
+EXPLAIN FORMAT=TREE SELECT * FROM t_limit ORDER BY id LIMIT 5;
+SELECT id FROM t_limit ORDER BY id LIMIT 5;
+
+DROP TABLE t_limit;
+DROP DATABASE rapid_limit_pushdown;

--- a/storage/rapid_engine/optimizer/optimizer.cpp
+++ b/storage/rapid_engine/optimizer/optimizer.cpp
@@ -278,11 +278,12 @@ void Optimizer::AddDefaultRules() {
   m_optimize_rules.emplace_back(std::make_unique<StorageIndexPrune>());
   // After predicates clarify needed columns
   m_optimize_rules.emplace_back(std::make_unique<ProjectionPruning>());
-  // TopNPushDown, AggregationPushDown and JoinReOrder remain available as experimental
-  // rules, but are deliberately not enabled by default. Their physical-plan
-  // rewrites require LIMIT/OFFSET representation and join
-  // multiplicity/type proofs that PlanNode does not yet carry; applying them
-  // without those proofs can change query results.
+  // Push a plain LIMIT/OFFSET into a scan only after predicate pushdown has
+  // removed every Filter that the scan can evaluate itself. Sorts, joins and
+  // aggregates remain barriers in the conservative implementation.
+  m_optimize_rules.emplace_back(std::make_unique<TopNPushDown>());
+  // AggregationPushDown and JoinReOrder remain experimental. Their rewrites
+  // require join multiplicity/type proofs that PlanNode does not yet carry.
   m_registered.store(true, std::memory_order_relaxed);
 }
 
@@ -324,6 +325,7 @@ bool Optimizer::translate_access_path(TranslateState *state, THD *thd, AccessPat
       if (path->type == AccessPath::INDEX_SCAN) {
         table = path->index_scan().table;
         scan->scan_type = ScanTable::ScanType::INDEX_SCAN;
+        scan->has_required_order = path->index_scan().use_order;
       } else if (path->type == AccessPath::INDEX_RANGE_SCAN) {
         const auto &irs = path->index_range_scan();
         if (irs.used_key_part != nullptr && irs.num_used_key_parts > 0 && irs.used_key_part[0].field != nullptr)
@@ -664,6 +666,7 @@ bool Optimizer::translate_access_path(TranslateState *state, THD *thd, AccessPat
       node->offset = limit_ap.offset;
       node->count_all_rows = limit_ap.count_all_rows;
       node->reject_multiple_rows = limit_ap.reject_multiple_rows;
+      node->send_records_override = limit_ap.send_records_override;
       node->children.push_back(std::move(child_state.plan_node));
       node->cost = path->cost();
 

--- a/storage/rapid_engine/optimizer/path/access_path.cpp
+++ b/storage/rapid_engine/optimizer/path/access_path.cpp
@@ -345,13 +345,17 @@ unique_ptr_destroy_only<RowIterator> PathGenerator::CreateIteratorFromAccessPath
         if (path->secondary_engine_data) {
           auto rapid_scan_param = static_cast<RapidScanParameters *>(path->secondary_engine_data);
 
-          // Store predicate description on the handler for EXPLAIN before moving.
+          // Store pushed operations on the handler for EXPLAIN before moving.
+          std::string extra_description;
           if (rapid_scan_param->prune_predicate) {
-            auto *rapid_handler = dynamic_cast<ha_rapid *>(param.table->file);
-            if (rapid_handler) {
-              rapid_handler->set_extra_description(" [filter: " + rapid_scan_param->prune_predicate->to_string() + "]");
-            }
+            extra_description += " [filter: " + rapid_scan_param->prune_predicate->to_string() + "]";
           }
+          if (rapid_scan_param->limit != HA_POS_ERROR)
+            extra_description += " [limit: " + std::to_string(rapid_scan_param->limit) + "]";
+          if (rapid_scan_param->offset != 0)
+            extra_description += " [offset: " + std::to_string(rapid_scan_param->offset) + "]";
+          auto *rapid_handler = dynamic_cast<ha_rapid *>(param.table->file);
+          if (rapid_handler) rapid_handler->set_extra_description(extra_description);
 
           predicate = std::move(rapid_scan_param->prune_predicate);
           projection = std::move(rapid_scan_param->projected_columns);

--- a/storage/rapid_engine/optimizer/query_plan.h
+++ b/storage/rapid_engine/optimizer/query_plan.h
@@ -132,6 +132,11 @@ class ScanTable : public PlanNode {
   // ORDER BY pushdown（TopN optimization）
   ORDER *order{nullptr};
 
+  // The source AccessPath was an ordered index scan used by MySQL to satisfy
+  // an ORDER BY. Rapid still converts it to its vectorized scan under forced
+  // secondary execution, but LIMIT must remain above that scan.
+  bool has_required_order{false};
+
   // Convert to AccessPath for execution.
   AccessPath *ToAccessPath(THD *thd) override;
 
@@ -299,7 +304,7 @@ class Limit : public PlanNode {
   ha_rows offset{0};
   bool count_all_rows{false};
   bool reject_multiple_rows{false};
-  ha_rows send_records_override{0};
+  ha_rows *send_records_override{nullptr};
 
   // Convert to AccessPath for execution.
   AccessPath *ToAccessPath(THD *thd) override;

--- a/storage/rapid_engine/optimizer/rules/condition_pushdown.cpp
+++ b/storage/rapid_engine/optimizer/rules/condition_pushdown.cpp
@@ -984,12 +984,38 @@ std::unordered_set<std::string> AggregationPushDown::get_available_tables(const 
 }
 
 void TopNPushDown::apply(Plan &root) {
-  // Disabled until the rule models MySQL's LIMIT_OFFSET representation
-  // exactly. AccessPath::limit is the exclusive row boundary (LIMIT +
-  // OFFSET), while the old rule treated it as the number of returned rows;
-  // merging it with filesort's Top-N limit could therefore drop OFFSET or
-  // return too many rows. Keeping the original operator placement is safe.
-  (void)root;
+  // Deliberately support only the correctness-obvious base case here. A LIMIT
+  // may be absorbed when its direct child is a scan, since no cardinality- or
+  // order-changing operator is crossed. PredicatePushDown runs before this
+  // rule, so a successfully pushed storage predicate is already part of the
+  // Scan node; a residual Filter remains an explicit barrier.
+  std::function<void(Plan &)> push_into_direct_scans = [&](Plan &node) {
+    if (!node) return;
+    for (Plan &child : node->children) push_into_direct_scans(child);
+
+    if (node->type() != PlanNode::Type::LIMIT) return;
+    auto *limit_node = static_cast<Limit *>(node.get());
+    if (limit_node->children.size() != 1 || !limit_node->children[0] ||
+        limit_node->children[0]->type() != PlanNode::Type::SCAN || limit_node->count_all_rows ||
+        limit_node->reject_multiple_rows || limit_node->send_records_override != nullptr)
+      return;
+
+    auto *scan = static_cast<ScanTable *>(limit_node->children[0].get());
+    if (scan->has_required_order) return;
+    // LIMIT_OFFSET stores an exclusive row boundary (returned rows +
+    // OFFSET), whereas RapidCursor::set_scan_limit() expects the number of
+    // rows to return after skipping OFFSET. Normalize the representation at
+    // the pushdown boundary.
+    scan->limit = limit_node->limit == HA_POS_ERROR
+                      ? HA_POS_ERROR
+                      : (limit_node->limit > limit_node->offset ? limit_node->limit - limit_node->offset : 0);
+    scan->offset = limit_node->offset;
+    const ha_rows child_rows = scan->estimated_rows;
+    const ha_rows after_offset = child_rows > scan->offset ? child_rows - scan->offset : 0;
+    scan->estimated_rows = scan->limit == HA_POS_ERROR ? after_offset : std::min(after_offset, scan->limit);
+    node = std::move(limit_node->children[0]);
+  };
+  push_into_direct_scans(root);
 }
 
 /**


### PR DESCRIPTION
enable limit-offset oper push-down to table scan layer.

Issues:#805

I hereby agree to the terms of the CLA available at: http://www.shannondata.ai/doc/cla/

## Summary

_enable limit-offset oper push-down to table scan layer._

- Fixes #805

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):