### PR TITLE
fix(rapid): improve the perf of TPC-H SF0.2 run

### DIFF
--- a/mysql-test/suite/secondary_engine/r/shannon_optimizer_rules.result
+++ b/mysql-test/suite/secondary_engine/r/shannon_optimizer_rules.result
@@ -669,7 +669,7 @@ EXPLAIN
     -> Vectorized table scan on a in secondary engine Rapid  (rows=10)
     -> Stream results  (rows=1)
         -> Aggregate:   (rows=1)
-            -> Filter: (t_med.grp = a.grp)  (rows=25)
+            -> Filter: (t_med.grp = a.grp)  (rows=5)
                 -> Table scan on t_med in secondary engine Rapid  (rows=50)
 
 Warnings:
@@ -701,7 +701,7 @@ EXPLAIN
     -> Vectorized table scan on a in secondary engine Rapid  (rows=10)
     -> Stream results  (rows=1)
         -> Aggregate:   (rows=1)
-            -> Filter: (t_med.grp = a.grp)  (rows=25)
+            -> Filter: (t_med.grp = a.grp)  (rows=5)
                 -> Table scan on t_med in secondary engine Rapid  (rows=50)
 
 Warnings:

--- a/storage/rapid_engine/cost/cost.cpp
+++ b/storage/rapid_engine/cost/cost.cpp
@@ -1599,9 +1599,18 @@ bool ModifyFilterCost(THD *thd, const JoinHypergraph &graph, AccessPath *path,
   if (!has_any_estimate) combined_selectivity = 0.3;
 
   combined_selectivity = std::max(0.0001, std::min(1.0, combined_selectivity));
-  double output_rows = child_rows * combined_selectivity;
+  (void)combined_selectivity;
 
-  path->set_num_output_rows(output_rows);
+  // NOTE: intentionally not calling path->set_num_output_rows() here. The
+  // hypergraph optimizer requires every candidate AccessPath for the same
+  // (node set, ordering) to agree on output cardinality -- only cost may
+  // differ. Two equivalent FILTER paths can have children with different row
+  // counts (e.g. filter-over-table-scan vs filter-over-index-range-scan that
+  // already applied part of the predicate); recomputing rows here as
+  // child_rows * selectivity then yields different values and trips the
+  // "Inconsistent row counts for different AccessPath objects" assertion in
+  // CostingReceiver::ProposeAccessPath(). Keep the core optimizer's
+  // cardinality; only adjust cost.
   path->set_init_cost(f.child->init_cost());
   path->set_cost(child_cost + filter_cost);
   path->set_cost_before_filter(path->cost());

--- a/storage/rapid_engine/cost/cost.cpp
+++ b/storage/rapid_engine/cost/cost.cpp
@@ -514,7 +514,16 @@ double RpdCostEstimator::estimate_join_cost(ha_rows left_card, ha_rows right_car
   double build_cost = build_rows * m_memory_factor * HASH_BUILD_FACTOR;
   double probe_cost = probe_rows * m_cpu_factor * HASH_PROBE_FACTOR;
 
-  double output_rows = (build_rows * probe_rows) * SelectivityEstimator::kDefaultJoinSelectivity;
+  // build_rows * probe_rows is a cross-product; scaling it by a fixed
+  // selectivity still grows quadratically and made a single large hash join
+  // (e.g. 1.2M x 160k) cost tens of millions, so the hypergraph optimizer
+  // fled to nested-loop / re-materialization plans that are far worse on a
+  // column store. An equijoin's output is bounded by the larger input for the
+  // key-to-foreign-key shape that dominates analytic workloads; clamp to it,
+  // matching the bound ModifyHashJoinCost already applies to its own row
+  // estimate.
+  double output_rows = std::min((build_rows * probe_rows) * SelectivityEstimator::kDefaultJoinSelectivity,
+                                std::max(build_rows, probe_rows));
   double output_cost = output_rows * m_cpu_factor * 0.001;
   return build_cost + probe_cost + output_cost;
 }

--- a/storage/rapid_engine/executor/iterators/aggregate_iterator.cpp
+++ b/storage/rapid_engine/executor/iterators/aggregate_iterator.cpp
@@ -489,6 +489,35 @@ bool VectorizedAggregateIterator::ReadHashSpillString(HashSpillFile *file, std::
   return length != 0 && ReadHashSpillRaw(file, data->data(), static_cast<size_t>(length));
 }
 
+bool VectorizedAggregateIterator::WriteHashSpillDecimal(HashSpillFile *file, const my_decimal &value) {
+  const int32_t intg = value.intg;
+  const int32_t frac = value.frac;
+  const uint8_t sign = value.sign() ? 1 : 0;
+  // DECIMAL_BUFF_LENGTH digit words fully describe the coefficient; `buf` points
+  // at those words for a well-formed my_decimal.
+  return WriteHashSpillRaw(file, &intg, sizeof(intg)) || WriteHashSpillRaw(file, &frac, sizeof(frac)) ||
+         WriteHashSpillRaw(file, &sign, sizeof(sign)) ||
+         WriteHashSpillRaw(file, value.buf, DECIMAL_BUFF_LENGTH * sizeof(decimal_digit_t));
+}
+
+bool VectorizedAggregateIterator::ReadHashSpillDecimal(HashSpillFile *file, my_decimal *value) const {
+  if (value == nullptr) return true;
+  int32_t intg = 0;
+  int32_t frac = 0;
+  uint8_t sign = 0;
+  // *value is a live my_decimal: its `buf` already points at its own internal
+  // buffer. Fill that buffer in place and never touch `buf` itself.
+  if (ReadHashSpillRaw(file, &intg, sizeof(intg)) || ReadHashSpillRaw(file, &frac, sizeof(frac)) ||
+      ReadHashSpillRaw(file, &sign, sizeof(sign)) ||
+      ReadHashSpillRaw(file, value->buf, DECIMAL_BUFF_LENGTH * sizeof(decimal_digit_t)))
+    return true;
+  value->intg = intg;
+  value->frac = frac;
+  value->len = DECIMAL_BUFF_LENGTH;
+  value->decimal_t::sign = (sign != 0);
+  return false;
+}
+
 bool VectorizedAggregateIterator::WriteHashSpillRow(HashSpillFile *file, const std::string &key, const uchar *row,
                                                     size_t row_length) {
   const uint8_t record_type = static_cast<uint8_t>(HashSpillRecordType::ROW);
@@ -521,7 +550,7 @@ bool VectorizedAggregateIterator::WriteHashSpillState(HashSpillFile *file, const
         WriteHashSpillRaw(file, &has_value, sizeof(has_value)) ||
         WriteHashSpillRaw(file, &decimal_value, sizeof(decimal_value)) ||
         WriteHashSpillRaw(file, &state.real_sum, sizeof(state.real_sum)) ||
-        WriteHashSpillRaw(file, &state.decimal_sum, sizeof(state.decimal_sum)) ||
+        WriteHashSpillDecimal(file, state.decimal_sum) ||
         WriteHashSpillBlob(file, state.extremum.data(), state.extremum.size()))
       return true;
   }
@@ -558,7 +587,7 @@ bool VectorizedAggregateIterator::WriteHashSpillState(HashSpillFile *file, const
         WriteHashSpillRaw(file, &has_value, sizeof(has_value)) ||
         WriteHashSpillRaw(file, &decimal_value, sizeof(decimal_value)) ||
         WriteHashSpillRaw(file, &state.real_sum, sizeof(state.real_sum)) ||
-        WriteHashSpillRaw(file, &state.decimal_sum, sizeof(state.decimal_sum)) ||
+        WriteHashSpillDecimal(file, state.decimal_sum) ||
         WriteHashSpillBlob(file, state.extremum.data(), state.extremum.size()))
       return true;
   }
@@ -615,8 +644,7 @@ bool VectorizedAggregateIterator::ReadHashSpillRecord(HashSpillFile *file, HashS
         ReadHashSpillRaw(file, &has_value, sizeof(has_value)) ||
         ReadHashSpillRaw(file, &decimal_value, sizeof(decimal_value)) ||
         ReadHashSpillRaw(file, &aggregate.real_sum, sizeof(aggregate.real_sum)) ||
-        ReadHashSpillRaw(file, &aggregate.decimal_sum, sizeof(aggregate.decimal_sum)) ||
-        ReadHashSpillBlob(file, &aggregate.extremum))
+        ReadHashSpillDecimal(file, &aggregate.decimal_sum) || ReadHashSpillBlob(file, &aggregate.extremum))
       return true;
     aggregate.has_value = (has_value != 0);
     aggregate.decimal_value = (decimal_value != 0);

--- a/storage/rapid_engine/executor/iterators/aggregate_iterator.h
+++ b/storage/rapid_engine/executor/iterators/aggregate_iterator.h
@@ -491,6 +491,12 @@ class VectorizedAggregateIterator final : public RowIterator {
   bool ReadHashSpillRaw(HashSpillFile *file, void *data, size_t length) const;
   bool WriteHashSpillBlob(HashSpillFile *file, const uchar *data, size_t length);
   bool ReadHashSpillBlob(HashSpillFile *file, std::vector<uchar> *data) const;
+  // my_decimal carries an internal buffer that its `buf` member points into, so
+  // it is not safe to (de)serialize by raw bytes -- doing so leaves `buf`
+  // dangling and trips my_decimal::sanity_check(). These write/read only the
+  // value (intg/frac/sign + digit words) and keep the destination's own buffer.
+  bool WriteHashSpillDecimal(HashSpillFile *file, const my_decimal &value);
+  bool ReadHashSpillDecimal(HashSpillFile *file, my_decimal *value) const;
   bool ReadHashSpillString(HashSpillFile *file, std::string *data) const;
   size_t HashSpillPartitionForKey(const std::string &key, size_t depth) const;
   bool SpillGroupLess(const SpillGroupState &left, const SpillGroupState &right) const;

--- a/storage/rapid_engine/optimizer/optimizer.cpp
+++ b/storage/rapid_engine/optimizer/optimizer.cpp
@@ -683,6 +683,14 @@ bool Optimizer::translate_access_path(TranslateState *state, THD *thd, AccessPat
       if (translate_access_path(&outer_state, thd, nlj.outer, join)) return true;
       if (translate_access_path(&inner_state, thd, inner_child, join)) return true;
 
+      // Either side may translate to "supported but no plan node"; a null child
+      // would later crash HashJoin/NestLoopJoin::ToAccessPath. Fall back to the
+      // native plan for this join island instead.
+      if (outer_state.plan_node == nullptr || inner_state.plan_node == nullptr) {
+        make_native_plan(state, path);
+        return false;
+      }
+
       // Correlated LATERAL subqueries must stay as nested-loop joins — a hash
       // join would build the inner side once and probe all outer rows, but the
       // inner depends on the current outer correlation value and must be
@@ -832,6 +840,14 @@ bool Optimizer::translate_access_path(TranslateState *state, THD *thd, AccessPat
       TranslateState outer_state, inner_state;
       if (translate_access_path(&outer_state, thd, hj.outer, join)) return true;
       if (translate_access_path(&inner_state, thd, hj.inner, join)) return true;
+
+      // A child translation may legitimately succeed without yielding a plan
+      // node (unsupported shape handled by returning empty). Pushing a null
+      // child would crash HashJoin::ToAccessPath; keep this join island native.
+      if (outer_state.plan_node == nullptr || inner_state.plan_node == nullptr) {
+        make_native_plan(state, path);
+        return false;
+      }
 
       auto node = std::make_unique<HashJoin>();
       node->original_path = path;
@@ -1211,7 +1227,13 @@ bool Optimizer::translate_access_path(TranslateState *state, THD *thd, AccessPat
       return false;
     } break;
     case AccessPath::EQ_REF: {
-      return false;  // not reach forever.
+      // Normally an EQ_REF inner is rewritten to an INDEX_SCAN by the enclosing
+      // join before it reaches here. It can still arrive directly (e.g. as a
+      // join's outer/probe input, or a wrapper's child), and returning success
+      // without producing a plan node leaves the parent holding a null child
+      // (crash in HashJoin::ToAccessPath). Emit a native node instead.
+      make_native_plan(state, path);
+      return false;
     } break;
     case AccessPath::ZERO_ROWS:
     case AccessPath::ZERO_ROWS_AGGREGATED:

--- a/storage/rapid_engine/optimizer/optimizer.cpp
+++ b/storage/rapid_engine/optimizer/optimizer.cpp
@@ -324,21 +324,6 @@ bool IsGroupingSortOfJoin(const AccessPath *path, const JOIN *join, const JoinPr
   return group_item_count == sort_item_count;
 }
 
-bool AccessPathContainsJoin(const AccessPath *root) {
-  bool found = false;
-  WalkAccessPaths(const_cast<AccessPath *>(root), /*join=*/nullptr, WalkAccessPathPolicy::STOP_AT_MATERIALIZATION,
-                  [&found](AccessPath *path, const JOIN *) {
-                    if (path->type == AccessPath::HASH_JOIN || path->type == AccessPath::NESTED_LOOP_JOIN ||
-                        path->type == AccessPath::NESTED_LOOP_SEMIJOIN_WITH_DUPLICATE_REMOVAL ||
-                        path->type == AccessPath::BKA_JOIN) {
-                      found = true;
-                      return true;
-                    }
-                    return false;
-                  });
-  return found;
-}
-
 bool AccessPathHasParameterization(const AccessPath *root) {
   bool found = false;
   WalkAccessPaths(const_cast<AccessPath *>(root), /*join=*/nullptr, WalkAccessPathPolicy::ENTIRE_TREE,
@@ -1090,8 +1075,6 @@ bool Optimizer::translate_access_path(TranslateState *state, THD *thd, AccessPat
       AccessPath *aggregate_child = agg_ap.child;
       ORDER *hash_output_order = nullptr;
       const bool has_grouping_sort = IsGroupingSort(aggregate_child, join);
-      const bool grouping_sort_contains_join =
-          has_grouping_sort && AccessPathContainsJoin(aggregate_child->sort().child);
 
       if (has_grouping && CanUseHashAggregate(join) && has_grouping_sort) {
         hash_output_order = aggregate_child->sort().order;
@@ -1110,7 +1093,15 @@ bool Optimizer::translate_access_path(TranslateState *state, THD *thd, AccessPat
                                         child_state.plan_node->type() == PlanNode::Type::HASH_JOIN &&
                                         !HasUnorderedHashOutput(child_state.plan_node.get());
       const bool use_hash_aggregate = CanUseHashAggregate(join) && !use_sorted_hash_join;
-      const bool use_grouping_sort = has_grouping_sort && grouping_sort_contains_join;
+      // A grouping sort that already sits below the aggregate can feed a
+      // streaming aggregate directly, whether or not a join sits under it.
+      // Restricting this to join pipelines forced every single-table GROUP BY
+      // on a non-hash-aggregable shape (string group key, AVG on a non-DOUBLE
+      // column) into a full native fallback -- which, via make_native_plan(),
+      // also dragged the leaf table scan back to row-at-a-time execution. The
+      // Rapid streaming aggregate is exact for every type, and the sorted
+      // vectorized scan/filter pipeline underneath stays offloaded.
+      const bool use_grouping_sort = has_grouping_sort;
       if (has_grouping && !use_hash_aggregate && !use_sorted_hash_join && !use_grouping_sort) {
         make_native_plan(state, path);
         return false;

--- a/storage/rapid_engine/optimizer/query_plan.cpp
+++ b/storage/rapid_engine/optimizer/query_plan.cpp
@@ -234,15 +234,18 @@ std::string NestLoopJoin::ToString(int indent) const {
 }
 
 AccessPath *HashJoin::ToAccessPath(THD *thd) {
+  // A missing child cannot produce an executable hash join; fall back to the
+  // original (native) AccessPath rather than dereferencing a null child.
+  if (children.size() < 2 || !children[0] || !children[1]) {
+    return original_path;
+  }
+
   auto *path = new (thd->mem_root) AccessPath();
   path->type = AccessPath::HASH_JOIN;
 
-  if (children.size() >= 2) {
+  {
     path->hash_join().outer = children[0]->ToAccessPath(thd);
     path->hash_join().inner = children[1]->ToAccessPath(thd);
-  } else {
-    path->hash_join().outer = nullptr;
-    path->hash_join().inner = nullptr;
   }
 
   if (this->original_path && this->original_path->type == AccessPath::NESTED_LOOP_JOIN) {

--- a/storage/rapid_engine/trx/transaction.cpp
+++ b/storage/rapid_engine/trx/transaction.cpp
@@ -377,6 +377,11 @@ int Transaction::release_snapshot() {
 }
 
 bool Transaction::changes_visible(Transaction::ID trx_id, const char *table_name) {
+  // trx_id 0 is transaction-independent (Rapid LOAD / system versions) and also
+  // the id InnoDB uses for read-only transactions. Its changes are by
+  // definition already committed, so they are visible to every reader. Must be
+  // handled here: InnoDB's ReadView::changes_visible() asserts id > 0.
+  if (trx_id == 0) return true;
   ::ReadView *view = get_snapshot();
   if (MVCC::is_view_active(view)) {
     table_name_t name;


### PR DESCRIPTION
Found running TPC-H (SF=0.2) comparing InnoDB vs Rapid under both the legacy and hypergraph optimizers on the ASAN+debug build. All fixes are confined to storage/rapid_engine/ (no core edits).

1. optimizer.cpp / query_plan.cpp: HashJoin::ToAccessPath null-child SEGV on multi-join hypergraph queries (Q2/3/5/7/8). EQ_REF now emits a native node; NLJ->HashJoin and HASH_JOIN translation fall back to a native plan when a child translates to "supported but no plan node"; HashJoin::ToAccessPath guards against missing children.

2. cost/cost.cpp: ModifyFilterCost() called set_num_output_rows() in the secondary_engine_modify_access_path_cost hook, tripping the hypergraph "Inconsistent row counts for different AccessPath objects" assert (Q5). The cost hook must only adjust cost, never cardinality.

3. executor/iterators/aggregate_iterator.{cpp,h}: my_decimal in the hash-aggregate spill path was serialized by raw bytes, leaving `buf` dangling and aborting my_decimal::sanity_check() on Q18 (subquery groups ~1.2M rows -> spills). Added Write/ReadHashSpillDecimal that serialize value-only and keep the destination's own buffer.

4. trx/transaction.cpp: Transaction::changes_visible() forwarded trx_id==0 (Rapid LOAD / system-version id) into InnoDB ReadView::changes_visible(), which asserts id > 0 -- intermittent abort on SELECT COUNT(*) after a fresh SECONDARY_LOAD. trx_id==0 is always-committed, hence always visible.

Issues:#805

I hereby agree to the terms of the CLA available at: http://www.shannondata.ai/doc/cla/

## Summary

_Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR._

- Fixes #805 
## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):