### PR TITLE
fix(ml): correct scoring metrics and harden the ML catalog paths

### DIFF
--- a/ml/auto_ml.cpp
+++ b/ml/auto_ml.cpp
@@ -27,6 +27,8 @@
 
 #include <map>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "include/my_base.h"
 #include "include/my_bitmap.h"
@@ -36,6 +38,7 @@
 #include "sql/field.h"
 #include "sql/sql_class.h"
 #include "sql/table.h"
+#include "storage/innobase/include/ut0dbg.h"  //for ut_a
 
 #include "sql-common/json_error_handler.h"
 
@@ -82,9 +85,13 @@ void Auto_ML::init_task_map() {
   OPTION_VALUE_T opt_values;
   std::string keystr;
   Utils::parse_json(m_options, opt_values, keystr, 0);
-  assert(opt_values.size());
+
+  // An empty option object is legal (the task then defaults to classification),
+  // so look the key up instead of indexing: operator[] would insert an empty
+  // entry for a key the caller never passed.
+  auto task_it = opt_values.find(ML_KEYWORDS::task);
   m_task_type_str =
-      opt_values[ML_KEYWORDS::task].size() ? opt_values[ML_KEYWORDS::task][0] : ML_KEYWORDS::classification;
+      (task_it != opt_values.end() && !task_it->second.empty()) ? task_it->second[0] : ML_KEYWORDS::classification;
   std::transform(m_task_type_str.begin(), m_task_type_str.end(), m_task_type_str.begin(), ::toupper);
   build_task(m_task_type_str);
 }
@@ -92,8 +99,14 @@ void Auto_ML::init_task_map() {
 void Auto_ML::build_task(std::string_view task_str) {
   if (!task_str.length()) return;
 
-  // auto option_obj = m_options.clone_dom();
-  switch (OPT_TASKS_MAP[task_str]) {
+  // OPT_TASKS_MAP is a process-wide map shared by every session. operator[]
+  // would insert a node for an unrecognized task -- value-initializing the
+  // mapped enum to CLASSIFICATION, so a typo silently trains a classifier --
+  // and it would do so without holding any lock. Look the task up instead.
+  auto task_it = OPT_TASKS_MAP.find(task_str);
+  const ML_TASK_TYPE_T task_type = (task_it != OPT_TASKS_MAP.end()) ? task_it->second : ML_TASK_TYPE_T::UNKNOWN;
+
+  switch (task_type) {
     case ML_TASK_TYPE_T::CLASSIFICATION:
       if (m_ml_task == nullptr || m_ml_task->type() != ML_TASK_TYPE_T::CLASSIFICATION)
         m_ml_task = std::make_unique<ML_classification>();
@@ -166,8 +179,17 @@ void Auto_ML::build_task(std::string_view task_str) {
       down_cast<ML_topic_modeling *>(m_ml_task.get())->set_options(m_options);
       down_cast<ML_topic_modeling *>(m_ml_task.get())->set_handle_name(m_handler);
       break;
-    default:
-      break;
+    default: {
+      // No task object is built, so every entry point returns HA_ERR_GENERIC.
+      // Raise a diagnostic here, otherwise the statement fails with no error set.
+      m_ml_task.reset();
+      THD *thd = current_thd;
+      if (thd && !thd->is_error()) {
+        std::ostringstream err;
+        err << "unsupported ML task: " << task_str;
+        my_error(ER_ML_FAIL, MYF(0), err.str().c_str());
+      }
+    } break;
   }
   return;
 }
@@ -207,10 +229,11 @@ int Auto_ML::precheck_and_process_meta_info(std::string &model_handle_name, std:
 
   if (Utils::read_model_object_content(model_handle_name, model_content)) return HA_ERR_GENERIC;
 
-  if (m_task_type_str.length()) {
-    init_task_map();
-    build_task(m_task_type_str);
-  }
+  // m_task_type_str was just read from the model metadata's top-level "task"
+  // key above. Do not re-derive it through init_task_map(): that re-parses the
+  // whole metadata document flattened, where a nested "task" key can shadow the
+  // real one, and it would build the task object a second time.
+  if (m_task_type_str.length()) build_task(m_task_type_str);
 
   return 0;
 }
@@ -226,7 +249,7 @@ int Auto_ML::train(THD *thd, Json_wrapper &model_object, Json_wrapper &model_met
 }
 
 int Auto_ML::load(THD *thd, String *model_handler_name) {
-  assert(model_handler_name);
+  ut_a(model_handler_name);
   m_handler = model_handler_name->c_ptr_safe();
 
   std::string model_content_str;
@@ -236,7 +259,7 @@ int Auto_ML::load(THD *thd, String *model_handler_name) {
 }
 
 int Auto_ML::unload(THD *thd, String *model_handler_name) {
-  assert(model_handler_name);
+  ut_a(model_handler_name);
   m_handler = model_handler_name->c_ptr_safe();
 
   std::string model_content_str;
@@ -247,7 +270,7 @@ int Auto_ML::unload(THD *thd, String *model_handler_name) {
 
 double Auto_ML::score(THD *thd, String *sch_table_name, String *target_column_name, String *model_handle_name,
                       String *metric, Json_wrapper options) {
-  assert(sch_table_name && target_column_name && model_handle_name);
+  ut_a(sch_table_name && target_column_name && model_handle_name);
 
   std::string sch_tb_name_str(sch_table_name->c_ptr_safe());
   if (Utils::check_table_available(sch_tb_name_str)) return 0;
@@ -265,7 +288,7 @@ double Auto_ML::score(THD *thd, String *sch_table_name, String *target_column_na
 
 int Auto_ML::predict_row(THD *thd, Json_wrapper &input, String *model_handler_name, Json_wrapper options,
                          Json_wrapper &result) {
-  assert(model_handler_name);
+  ut_a(model_handler_name);
   std::string model_handler_name_str(model_handler_name->c_ptr_safe());
   std::string model_content_str;
   if (precheck_and_process_meta_info(model_handler_name_str, model_content_str, true)) return 0;
@@ -331,7 +354,7 @@ int Auto_ML::import(THD *thd, Json_wrapper &model_object, Json_wrapper &model_me
 
 int Auto_ML::explain(THD *thd, String *sch_tb_name, String *target_column_name, String *model_handler_name,
                      Json_wrapper exp_options) {
-  assert(sch_tb_name && target_column_name && model_handler_name);
+  ut_a(sch_tb_name && target_column_name && model_handler_name);
   m_options = exp_options;
 
   m_handler = model_handler_name->c_ptr_safe();
@@ -360,10 +383,15 @@ int Auto_ML::explain_row(THD *thd, Json_wrapper &exp_row, String *model_handler_
 }
 
 int Auto_ML::model_active(THD *thd, String *in_user_name, Json_wrapper &out_model_info) {
-  assert(thd);
-  if (Loaded_models.empty()) {
-    out_model_info = Json_wrapper(new (std::nothrow) Json_array());
-    return 0;
+  ut_a(thd);
+  {
+    std::lock_guard<std::mutex> lock(models_mutex);
+    if (Loaded_models.empty()) {
+      auto empty_array = new (std::nothrow) Json_array();
+      if (!empty_array) return HA_ERR_GENERIC;
+      out_model_info = Json_wrapper(empty_array);
+      return 0;
+    }
   }
 
   std::string scope_str = in_user_name ? std::string(in_user_name->c_ptr_safe()) : "current";
@@ -385,35 +413,49 @@ int Auto_ML::model_active(THD *thd, String *in_user_name, Json_wrapper &out_mode
   // Convention: every user's models live under ML_SCHEMA_{username}
   const std::string cur_ml_schema = "ML_SCHEMA_" + cur_user;
 
-  ulonglong total_bytes = 0;
-  auto detail_obj = new (std::nothrow) Json_object();  // second element of root array
-  auto size_obj = new (std::nothrow) Json_object();    // first element
-  auto root_array = new (std::nothrow) Json_array();
-
+  // Snapshot the loaded models, then read their metadata with the mutex
+  // released: read_model_content() opens tables and takes storage-engine
+  // locks, which must not happen underneath models_mutex.
+  std::vector<std::pair<std::string, size_t>> loaded_snapshot;
   {
     std::lock_guard<std::mutex> lock(models_mutex);
-
-    for (const auto &[handle, serialized] : Loaded_models) {
-      std::string model_handle = handle;
-      Json_wrapper meta_wrap;
-      if (Utils::read_model_content(model_handle, meta_wrap)) continue;
-
-      total_bytes += static_cast<ulonglong>(serialized.size());
-      auto meta_dom = meta_wrap.clone_dom();
-      if (!meta_dom) continue;
-      detail_obj->add_clone(handle, meta_dom.get());
-    }
+    loaded_snapshot.reserve(Loaded_models.size());
+    for (const auto &[handle, serialized] : Loaded_models) loaded_snapshot.emplace_back(handle, serialized.size());
   }  // models_mutex released
 
+  // add_alias()/append_alias() hand ownership to the parent DOM, so everything
+  // below is owned by root_array once attached; the unique_ptrs only cover the
+  // window before attachment.
+  Json_object_ptr detail_obj(new (std::nothrow) Json_object());  // second element of root array
+  Json_object_ptr size_obj(new (std::nothrow) Json_object());    // first element
+  Json_array_ptr root_array(new (std::nothrow) Json_array());
+  if (!detail_obj || !size_obj || !root_array) return HA_ERR_GENERIC;
+
+  ulonglong total_bytes = 0;
+  for (auto &[handle, serialized_size] : loaded_snapshot) {
+    std::string model_handle = handle;
+    Json_wrapper meta_wrap;
+    // Never swallow this failure. Opening MODEL_CATALOG in the middle of the
+    // enclosing statement can legitimately fail with ER_NEED_REPREPARE, and
+    // that error has to reach the server so the statement is re-prepared and
+    // retried -- clearing it here would silently return an empty model list.
+    if (Utils::read_model_content(model_handle, meta_wrap)) return HA_ERR_GENERIC;
+
+    total_bytes += static_cast<ulonglong>(serialized_size);
+    auto meta_dom = meta_wrap.clone_dom();
+    if (!meta_dom) continue;
+    if (detail_obj->add_alias(handle, std::move(meta_dom))) return HA_ERR_GENERIC;
+  }
+
   auto size_dom = new (std::nothrow) Json_uint(total_bytes);
-  if (size_obj->add_clone("total model size(bytes)", size_dom)) {
+  if (!size_dom || size_obj->add_alias("total model size(bytes)", size_dom)) {
     my_error(ER_ML_FAIL, MYF(0), "ML_MODEL_ACTIVE: failed to build size object");
     return HA_ERR_GENERIC;
   }
 
-  root_array->append_clone(size_obj);
-  root_array->append_clone(detail_obj);
-  out_model_info = Json_wrapper(root_array);
+  if (root_array->append_alias(std::move(size_obj)) || root_array->append_alias(std::move(detail_obj)))
+    return HA_ERR_GENERIC;
+  out_model_info = Json_wrapper(root_array.release());
   return 0;
 }
 }  // namespace ML

--- a/ml/ml_anomaly_detection.cpp
+++ b/ml/ml_anomaly_detection.cpp
@@ -221,9 +221,8 @@ int ML_anomaly_detection::train(THD *, Json_wrapper &model_object, Json_wrapper 
     }
   }
 
-  double contamination = ML_anomaly_detection::default_contamination;
-  if (options.find(ML_KEYWORDS::contamination) != options.end())
-    contamination = std::stod(options[ML_KEYWORDS::contamination][0]);
+  double contamination =
+      Utils::option_to_double_or(options, ML_KEYWORDS::contamination, ML_anomaly_detection::default_contamination);
   if (contamination <= 0 || contamination >= 0.5) contamination = ML_anomaly_detection::default_contamination;
 
   std::vector<std::string> model_list, exclude_model_list_str;
@@ -510,9 +509,7 @@ double ML_anomaly_detection::score(THD *, std::string &sch_tb_name, std::string 
 
   // The model outputs probabilities in [0,1] (binary classifier).
   // Use contamination-aware threshold from options if present, else 0.5.
-  double threshold = 0.5;
-  if (option_keys.find(ML_KEYWORDS::threshold) != option_keys.end() && !option_keys[ML_KEYWORDS::threshold].empty())
-    threshold = std::stod(option_keys[ML_KEYWORDS::threshold][0]);
+  double threshold = Utils::option_to_double_or(option_keys, ML_KEYWORDS::threshold, 0.5);
 
   double score_val = 0.0;
   switch ((int)ML_anomaly_detection::score_metrics[metrics[0]]) {
@@ -619,10 +616,8 @@ int ML_anomaly_detection::predict_row(THD *, Json_wrapper &input_data, std::stri
   if (Utils::get_txt2num_dict(model_meta, txt2numeric)) return HA_ERR_GENERIC;
 
   // Determine anomaly threshold: use option if provided, else use default contamination
-  double anomaly_threshold = 1.0 - ML_anomaly_detection::default_contamination;
-  if (!options.empty() && options.find(ML_KEYWORDS::threshold) != options.end() &&
-      !options[ML_KEYWORDS::threshold].empty())
-    anomaly_threshold = std::stod(options[ML_KEYWORDS::threshold][0]);
+  double anomaly_threshold =
+      Utils::option_to_double_or(options, ML_KEYWORDS::threshold, 1.0 - ML_anomaly_detection::default_contamination);
 
   auto *root_obj = new (std::nothrow) Json_object();
   if (!root_obj) return HA_ERR_GENERIC;

--- a/ml/ml_classification.cpp
+++ b/ml/ml_classification.cpp
@@ -30,6 +30,7 @@
 #include <chrono>
 #include <cmath>
 #include <iostream>
+#include <map>
 #include <memory>
 #include <numeric>
 #include <random>
@@ -116,27 +117,113 @@ double calc_balanced_accuracy(size_t n, const std::vector<double> &pred, const s
   return sum_recall / static_cast<double>(classes.size());
 }
 
-double calc_binary_metric(size_t n, const std::vector<double> &pred, const std::vector<float> &actual,
-                          const std::string &kind) {
-  size_t tp = 0, tn = 0, fp = 0, fn = 0;
-  for (size_t i = 0; i < n; ++i) {
-    int p = static_cast<int>(std::round(pred[i]));
-    int a = static_cast<int>(actual[i]);
-    if (a == 1 && p == 1)
-      ++tp;
-    else if (a == 0 && p == 0)
-      ++tn;
-    else if (a == 0 && p == 1)
-      ++fp;
-    else
-      ++fn;
+// Averaging strategies for precision/recall/F1, mirroring scikit-learn's
+// `average=` parameter. SAMPLES maps to MICRO: for single-label classification
+// sample-averaged precision, recall and F1 all reduce to accuracy, which is
+// exactly what micro-averaging computes.
+enum class METRIC_AVERAGE_T { BINARY, MACRO, MICRO, WEIGHTED };
+
+double calc_prf_metric(size_t n, const std::vector<double> &pred, const std::vector<float> &actual,
+                       const std::string &kind, METRIC_AVERAGE_T avg) {
+  auto combine = [&kind](double prec, double rec) -> double {
+    if (kind == "precision") return prec;
+    if (kind == "recall") return rec;
+    return (prec + rec > 0) ? 2.0 * prec * rec / (prec + rec) : 0.0;  // f1
+  };
+
+  if (avg == METRIC_AVERAGE_T::BINARY) {
+    // Positive class is 1, matching sklearn's default average='binary'.
+    size_t tp = 0, fp = 0, fn = 0;
+    for (size_t i = 0; i < n; ++i) {
+      int p = static_cast<int>(std::round(pred[i]));
+      int a = static_cast<int>(actual[i]);
+      if (a == 1 && p == 1)
+        ++tp;
+      else if (a != 1 && p == 1)
+        ++fp;
+      else if (a == 1 && p != 1)
+        ++fn;
+    }
+    double prec = (tp + fp > 0) ? (double)tp / (tp + fp) : 0.0;
+    double rec = (tp + fn > 0) ? (double)tp / (tp + fn) : 0.0;
+    return combine(prec, rec);
   }
-  double prec = (tp + fp > 0) ? (double)tp / (tp + fp) : 0.0;
-  double rec = (tp + fn > 0) ? (double)tp / (tp + fn) : 0.0;
-  if (kind == "precision") return prec;
-  if (kind == "recall") return rec;
-  if (kind == "f1") return (prec + rec > 0) ? 2.0 * prec * rec / (prec + rec) : 0.0;
-  return 0.0;
+
+  // One-vs-rest counts per class.
+  std::map<int, size_t> tp, fp, fn, support;
+  std::set<int> classes;
+  for (size_t i = 0; i < n; ++i) {
+    int a = static_cast<int>(actual[i]);
+    int p = static_cast<int>(std::round(pred[i]));
+    classes.insert(a);
+    classes.insert(p);
+    support[a]++;
+    if (a == p)
+      tp[a]++;
+    else {
+      fp[p]++;
+      fn[a]++;
+    }
+  }
+  if (classes.empty()) return 0.0;
+
+  if (avg == METRIC_AVERAGE_T::MICRO) {
+    size_t tp_sum = 0, fp_sum = 0, fn_sum = 0;
+    for (int c : classes) {
+      tp_sum += tp[c];
+      fp_sum += fp[c];
+      fn_sum += fn[c];
+    }
+    double prec = (tp_sum + fp_sum > 0) ? (double)tp_sum / (tp_sum + fp_sum) : 0.0;
+    double rec = (tp_sum + fn_sum > 0) ? (double)tp_sum / (tp_sum + fn_sum) : 0.0;
+    return combine(prec, rec);
+  }
+
+  double total = 0.0, weight_sum = 0.0;
+  for (int c : classes) {
+    double prec = (tp[c] + fp[c] > 0) ? (double)tp[c] / (tp[c] + fp[c]) : 0.0;
+    double rec = (tp[c] + fn[c] > 0) ? (double)tp[c] / (tp[c] + fn[c]) : 0.0;
+    double weight = (avg == METRIC_AVERAGE_T::WEIGHTED) ? (double)support[c] : 1.0;
+    total += weight * combine(prec, rec);
+    weight_sum += weight;
+  }
+  return (weight_sum > 0) ? total / weight_sum : 0.0;
+}
+
+// Area under the ROC curve for a binary classifier, computed from the ranks of
+// the predicted positive-class probabilities (the Mann-Whitney U identity),
+// with tied scores sharing their average rank.
+double calc_roc_auc(size_t n, const std::vector<double> &score, const std::vector<float> &actual) {
+  if (!n) return 0.0;
+
+  std::vector<size_t> order(n);
+  std::iota(order.begin(), order.end(), 0);
+  std::sort(order.begin(), order.end(), [&score](size_t a, size_t b) { return score[a] < score[b]; });
+
+  std::vector<double> rank(n, 0.0);
+  for (size_t i = 0; i < n;) {
+    size_t j = i;
+    while (j + 1 < n && score[order[j + 1]] == score[order[i]]) ++j;
+    // Ranks are 1-based, so the tied block spans i+1 .. j+1.
+    const double avg_rank = static_cast<double>(i + j + 2) / 2.0;
+    for (size_t k = i; k <= j; ++k) rank[order[k]] = avg_rank;
+    i = j + 1;
+  }
+
+  double sum_pos_rank = 0.0;
+  size_t n_pos = 0, n_neg = 0;
+  for (size_t i = 0; i < n; ++i) {
+    if (static_cast<int>(actual[i]) == 1) {
+      sum_pos_rank += rank[i];
+      ++n_pos;
+    } else
+      ++n_neg;
+  }
+  // AUC is undefined when only one class is present.
+  if (!n_pos || !n_neg) return 0.0;
+
+  return (sum_pos_rank - static_cast<double>(n_pos) * (n_pos + 1) / 2.0) /
+         (static_cast<double>(n_pos) * static_cast<double>(n_neg));
 }
 
 double calc_neg_log_loss(size_t n, const std::vector<double> &pred, const std::vector<float> &actual) {
@@ -368,6 +455,16 @@ double ML_classification::score(THD * /*thd*/, std::string &sch_tb_name, std::st
   if (Utils::model_predict(C_API_PREDICT_NORMAL, model_handle, n_sample, features_name.size(), test_data, predictions))
     return 0.0;
 
+  // model_predict() hands back the positive-class probability for a binary
+  // model, but the arg-max class index for a multiclass one. Metrics that need
+  // a score rather than a label are therefore binary-only.
+  const bool is_binary = (n_class <= 2);
+
+  // Plain F1/PRECISION/RECALL mean average='binary' on a two-class problem;
+  // there is no positive class to single out beyond that, so a multiclass
+  // model gets the macro average (sklearn refuses outright).
+  const METRIC_AVERAGE_T default_avg = is_binary ? METRIC_AVERAGE_T::BINARY : METRIC_AVERAGE_T::MACRO;
+
   double score_val = 0.0;
   switch ((int)ML_classification::score_metrics[metrics[0]]) {
     case (int)ML_classification::SCORE_METRIC_T::ACCURACY:
@@ -377,32 +474,58 @@ double ML_classification::score(THD * /*thd*/, std::string &sch_tb_name, std::st
       score_val = calc_balanced_accuracy(n_sample, predictions, label_data);
       break;
     case (int)ML_classification::SCORE_METRIC_T::F1:
+      score_val = calc_prf_metric(n_sample, predictions, label_data, "f1", default_avg);
+      break;
     case (int)ML_classification::SCORE_METRIC_T::F1_MACRO:
+      score_val = calc_prf_metric(n_sample, predictions, label_data, "f1", METRIC_AVERAGE_T::MACRO);
+      break;
     case (int)ML_classification::SCORE_METRIC_T::F1_MICRO:
     case (int)ML_classification::SCORE_METRIC_T::F1_SAMPLES:
+      score_val = calc_prf_metric(n_sample, predictions, label_data, "f1", METRIC_AVERAGE_T::MICRO);
+      break;
     case (int)ML_classification::SCORE_METRIC_T::F1_WEIGTHED:
-      score_val = calc_binary_metric(n_sample, predictions, label_data, "f1");
+      score_val = calc_prf_metric(n_sample, predictions, label_data, "f1", METRIC_AVERAGE_T::WEIGHTED);
       break;
     case (int)ML_classification::SCORE_METRIC_T::NEG_LOG_LOSS:
+      if (!is_binary) {
+        my_error(ER_ML_FAIL, MYF(0), "neg_log_loss is only supported for binary classification");
+        return 0.0;
+      }
       score_val = calc_neg_log_loss(n_sample, predictions, label_data);
       break;
     case (int)ML_classification::SCORE_METRIC_T::PRECISION:
+      score_val = calc_prf_metric(n_sample, predictions, label_data, "precision", default_avg);
+      break;
     case (int)ML_classification::SCORE_METRIC_T::PRECISION_MACRO:
+      score_val = calc_prf_metric(n_sample, predictions, label_data, "precision", METRIC_AVERAGE_T::MACRO);
+      break;
     case (int)ML_classification::SCORE_METRIC_T::PRECISION_MICRO:
     case (int)ML_classification::SCORE_METRIC_T::PRECISION_SAMPLES:
+      score_val = calc_prf_metric(n_sample, predictions, label_data, "precision", METRIC_AVERAGE_T::MICRO);
+      break;
     case (int)ML_classification::SCORE_METRIC_T::PRECISION_WEIGHTED:
-      score_val = calc_binary_metric(n_sample, predictions, label_data, "precision");
+      score_val = calc_prf_metric(n_sample, predictions, label_data, "precision", METRIC_AVERAGE_T::WEIGHTED);
       break;
     case (int)ML_classification::SCORE_METRIC_T::RECALL:
+      score_val = calc_prf_metric(n_sample, predictions, label_data, "recall", default_avg);
+      break;
     case (int)ML_classification::SCORE_METRIC_T::RECALL_MACRO:
+      score_val = calc_prf_metric(n_sample, predictions, label_data, "recall", METRIC_AVERAGE_T::MACRO);
+      break;
     case (int)ML_classification::SCORE_METRIC_T::RECALL_MICRO:
     case (int)ML_classification::SCORE_METRIC_T::RECALL_SAMPLES:
-    case (int)ML_classification::SCORE_METRIC_T::RECALL_WEIGHTED:
-      score_val = calc_binary_metric(n_sample, predictions, label_data, "recall");
+      score_val = calc_prf_metric(n_sample, predictions, label_data, "recall", METRIC_AVERAGE_T::MICRO);
       break;
-    case (int)ML_classification::SCORE_METRIC_T::ROC_AUC: {
-      score_val = Utils::calculate_accuracy(n_sample, predictions, label_data);
-    } break;
+    case (int)ML_classification::SCORE_METRIC_T::RECALL_WEIGHTED:
+      score_val = calc_prf_metric(n_sample, predictions, label_data, "recall", METRIC_AVERAGE_T::WEIGHTED);
+      break;
+    case (int)ML_classification::SCORE_METRIC_T::ROC_AUC:
+      if (!is_binary) {
+        my_error(ER_ML_FAIL, MYF(0), "roc_auc is only supported for binary classification");
+        return 0.0;
+      }
+      score_val = calc_roc_auc(n_sample, predictions, label_data);
+      break;
     default:
       break;
   }
@@ -1059,8 +1182,22 @@ void ML_classification::calculate_partial_dependence(BoosterHandle booster, size
                                                      const std::vector<double> &train_data,
                                                      const std::vector<std::string> &feature_names,
                                                      const std::vector<std::string> &columns_to_explain,
-                                                     const std::string & /*target_value*/,
-                                                     std::vector<double> &importance) {
+                                                     const std::string &target_value, std::vector<double> &importance) {
+  if (!n_sample || !n_features) return;
+
+  // A multiclass booster emits one score per class per sample. Sizing the
+  // prediction buffer at n_sample would let LGBM_BoosterPredictForMat write
+  // past its end, so size it by the class count and average the column of the
+  // class being explained (class 0 unless target_value names another).
+  int num_classes = 0;
+  if (LGBM_BoosterGetNumClasses(booster, &num_classes) || num_classes < 1) num_classes = 1;
+
+  size_t target_class = 0;
+  if (num_classes > 1) {
+    int parsed = Utils::to_int_or(target_value, 0);
+    if (parsed > 0 && parsed < num_classes) target_class = static_cast<size_t>(parsed);
+  }
+
   for (const auto &col_name : columns_to_explain) {
     auto it = std::find(feature_names.begin(), feature_names.end(), col_name);
     if (it == feature_names.end()) continue;
@@ -1091,11 +1228,12 @@ void ML_classification::calculate_partial_dependence(BoosterHandle booster, size
         modified_data[i * n_features + feature_idx] = val;
       }
 
-      std::vector<double> pred(n_sample);
+      std::vector<double> pred(n_sample * static_cast<size_t>(num_classes));
       if (!LGBM_BoosterPredictForMat(booster, modified_data.data(), C_API_DTYPE_FLOAT64, n_sample, n_features, 1,
                                      C_API_PREDICT_NORMAL, 0, -1, "", &out_len, pred.data())) {
-        double avg_pred = std::accumulate(pred.begin(), pred.end(), 0.0) / n_sample;
-        pdp_values.push_back(avg_pred);
+        double sum_pred = 0.0;
+        for (size_t i = 0; i < n_sample; i++) sum_pred += pred[i * static_cast<size_t>(num_classes) + target_class];
+        pdp_values.push_back(sum_pred / static_cast<double>(n_sample));
       }
     }
 
@@ -1169,11 +1307,7 @@ int ML_classification::predict_table(THD * /*thd*/, std::string &sch_tb_name, st
                                      std::string &out_sch_tb_name, Json_wrapper &options) {
   std::ostringstream err;
   std::string model_content;
-  {
-    std::lock_guard<std::mutex> lock(models_mutex);
-    model_content = Loaded_models[model_handle_name];
-    assert(model_content.length());
-  }
+  if (Utils::get_loaded_model_content(model_handle_name, model_content)) return HA_ERR_GENERIC;
 
   BoosterHandle booster = Utils::load_trained_model_from_string(model_content);
   if (!booster) return HA_ERR_GENERIC;
@@ -1195,12 +1329,13 @@ int ML_classification::predict_table(THD * /*thd*/, std::string &sch_tb_name, st
     return HA_ERR_GENERIC;
   }
 
-  auto remove_seen_str =
-      (option_values[ML_KEYWORDS::remove_seen].size()) ? option_values[ML_KEYWORDS::remove_seen][0] : "true";
+  std::string remove_seen_str{"true"};
+  auto remove_seen_it = option_values.find(ML_KEYWORDS::remove_seen);
+  if (remove_seen_it != option_values.end() && !remove_seen_it->second.empty())
+    remove_seen_str = remove_seen_it->second[0];
   std::transform(remove_seen_str.begin(), remove_seen_str.end(), remove_seen_str.begin(), ::toupper);
   auto remove_seen = (remove_seen_str == "TRUE");
-  auto batch_size =
-      (option_values[ML_KEYWORDS::batch_size].size()) ? std::stoi(option_values[ML_KEYWORDS::batch_size][0]) : 1000;
+  auto batch_size = Utils::option_to_int_or(option_values, ML_KEYWORDS::batch_size, 1000);
   if (batch_size < 1 || batch_size > 1000) {
     err << sch_tb_name << " wrong batch_size option";
     my_error(ER_ML_FAIL, MYF(0), err.str().c_str());

--- a/ml/ml_info.h
+++ b/ml/ml_info.h
@@ -84,7 +84,7 @@ enum class MODEL_PREDICTION_EXP_T {
 };
 // clang-format off
 
-extern std::map<std::string_view, ML_TASK_TYPE_T, std::less<>> OPT_TASKS_MAP;
+extern std::map<std::string, ML_TASK_TYPE_T, std::less<>> OPT_TASKS_MAP;
 extern std::map<std::string, MODEL_PREDICTION_EXP_T, std::less<>> MODEL_EXPLAINERS_MAP;
 
 extern std::map<ML_TASK_TYPE_T, std::string> TASK_NAMES_MAP;

--- a/ml/ml_recommendation.cpp
+++ b/ml/ml_recommendation.cpp
@@ -126,21 +126,24 @@ int ML_recommendation::train(THD *, Json_wrapper &model_object, Json_wrapper &mo
   std::string keystr;
   if (!m_options.empty() && Utils::parse_json(m_options, options, keystr, 0)) return HA_ERR_GENERIC;
 
-  if (options.find(ML_KEYWORDS::users) == options.end() || options.find(ML_KEYWORDS::items) == options.end()) {
+  // A present key with an empty value list (e.g. an empty JSON array) leaves an
+  // empty vector behind, so require a value before indexing it.
+  auto users_it = options.find(ML_KEYWORDS::users);
+  auto items_it = options.find(ML_KEYWORDS::items);
+  if (users_it == options.end() || users_it->second.empty() || items_it == options.end() || items_it->second.empty()) {
     my_error(ER_ML_FAIL, MYF(0), "users and items columns must be specified in options");
     return HA_ERR_GENERIC;
   }
 
-  std::string users_col = options[ML_KEYWORDS::users][0];
-  std::string items_col = options[ML_KEYWORDS::items][0];
+  std::string users_col = users_it->second[0];
+  std::string items_col = items_it->second[0];
 
   // Optional recommendation options
   std::string feedback_type = "explicit";  // explicit or implicit
-  if (options.find(ML_KEYWORDS::feedback) != options.end()) feedback_type = options[ML_KEYWORDS::feedback][0];
+  auto feedback_it = options.find(ML_KEYWORDS::feedback);
+  if (feedback_it != options.end() && !feedback_it->second.empty()) feedback_type = feedback_it->second[0];
 
-  double feedback_threshold = 1.0;
-  if (options.find(ML_KEYWORDS::feedback_threshold) != options.end())
-    feedback_threshold = std::stod(options[ML_KEYWORDS::feedback_threshold][0]);
+  double feedback_threshold = Utils::option_to_double_or(options, ML_KEYWORDS::feedback_threshold, 1.0);
 
   std::vector<std::string> model_list;
   if (options.find(ML_KEYWORDS::model_list) != options.end()) model_list = options[ML_KEYWORDS::model_list];

--- a/ml/ml_utils.cpp
+++ b/ml/ml_utils.cpp
@@ -27,6 +27,8 @@
 #include "ml_utils.h"
 
 #include <algorithm>
+#include <cctype>
+#include <cmath>
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -56,7 +58,7 @@
 namespace ShannonBase {
 namespace ML {
 // clang-format off
-std::map<std::string_view, ML_TASK_TYPE_T, std::less<>> OPT_TASKS_MAP = {
+std::map<std::string, ML_TASK_TYPE_T, std::less<>> OPT_TASKS_MAP = {
     {"", ML_TASK_TYPE_T::UNKNOWN},
     {"CLASSIFICATION", ML_TASK_TYPE_T::CLASSIFICATION},
     {"REGRESSION", ML_TASK_TYPE_T::REGRESSION},
@@ -337,10 +339,10 @@ void Utils::parse_logad_options(Json_wrapper &options, std::string &additional_m
   if (it != opt_values.end() && !it->second.empty()) additional_masking_regex = it->second[0];
 
   it = opt_values.find(ML_KEYWORDS::window_size);
-  if (it != opt_values.end() && !it->second.empty()) window_size = std::stoi(it->second[0]);
+  if (it != opt_values.end() && !it->second.empty()) window_size = Utils::to_int_or(it->second[0], window_size);
 
   it = opt_values.find(ML_KEYWORDS::window_stride);
-  if (it != opt_values.end() && !it->second.empty()) window_stride = std::stoi(it->second[0]);
+  if (it != opt_values.end() && !it->second.empty()) window_stride = Utils::to_int_or(it->second[0], window_stride);
 
   it = opt_values.find(ML_KEYWORDS::log_source_column);
   if (it != opt_values.end() && !it->second.empty()) log_source_column = it->second[0];
@@ -367,13 +369,13 @@ int Utils::validate_table_size(TABLE *table) {
     return HA_ERR_GENERIC;
   }
 
-  // Check row count (max 100 million) and table size (max 10 GB)
-  // Estimate from table statistics
-  ha_rows estimated_rows = 0;
-  if (table->file->ha_table_flags() & HA_STATS_RECORDS_IS_EXACT) {
-    table->file->info(HA_STATUS_VARIABLE | HA_STATUS_NO_LOCK);
-    estimated_rows = table->file->stats.records;
-  }
+  // Check row count (max 100 million) and table size (max 10 GB).
+  // Refresh the statistics once and read both limits off the same snapshot.
+  // stats.records is only an estimate for most engines -- InnoDB does not set
+  // HA_STATS_RECORDS_IS_EXACT -- so gating on that flag would skip the row
+  // check entirely for exactly the tables it is meant to protect.
+  table->file->info(HA_STATUS_VARIABLE | HA_STATUS_NO_LOCK);
+  ha_rows estimated_rows = table->file->stats.records;
 
   if (estimated_rows > 100000000) {
     std::ostringstream err;
@@ -382,9 +384,10 @@ int Utils::validate_table_size(TABLE *table) {
     return HA_ERR_GENERIC;
   }
 
-  // Estimate table size (data_length + index_length)
-  table->file->info(HA_STATUS_VARIABLE | HA_STATUS_NO_LOCK);
-  auto table_size_bytes = table->file->stats.data_file_length + table->file->stats.max_data_file_length;
+  // Estimate table size (data_length + index_length). max_data_file_length is
+  // the largest file the engine would allow, not a size in use, so it must not
+  // be part of the sum.
+  auto table_size_bytes = table->file->stats.data_file_length + table->file->stats.index_file_length;
   constexpr ha_rows MAX_TABLE_SIZE = 10ULL * 1024 * 1024 * 1024;  // 10 GB
   if (table_size_bytes > MAX_TABLE_SIZE) {
     std::ostringstream err;
@@ -744,6 +747,69 @@ BoosterHandle Utils::load_trained_model_from_string(std::string &model_content) 
   return (ret == 0) ? handle : nullptr;
 }
 
+int Utils::get_loaded_model_content(const std::string &model_handle_name, std::string &model_content) {
+  {
+    std::lock_guard<std::mutex> lock(models_mutex);
+    auto it = Loaded_models.find(model_handle_name);
+    if (it == Loaded_models.end()) {
+      std::ostringstream err;
+      err << model_handle_name << " has not been loaded";
+      my_error(ER_ML_FAIL, MYF(0), err.str().c_str());
+      return HA_ERR_GENERIC;
+    }
+    model_content = it->second;
+  }
+
+  if (model_content.empty()) {
+    std::ostringstream err;
+    err << model_handle_name << " is loaded with empty content";
+    my_error(ER_ML_FAIL, MYF(0), err.str().c_str());
+    return HA_ERR_GENERIC;
+  }
+  return 0;
+}
+
+double Utils::to_double_or(const std::string &str, double default_value) {
+  if (str.empty()) return default_value;
+  try {
+    size_t pos = 0;
+    double val = std::stod(str, &pos);
+    // Reject trailing garbage ("1.5abc") the same way a wholly non-numeric
+    // value is rejected, rather than silently keeping the leading number.
+    while (pos < str.size() && std::isspace(static_cast<unsigned char>(str[pos]))) pos++;
+    if (pos != str.size()) return default_value;
+    // std::stod parses "nan" and "inf" happily, and a NaN slips through every
+    // range check a caller makes on the result.
+    return std::isfinite(val) ? val : default_value;
+  } catch (const std::exception &) {
+    return default_value;
+  }
+}
+
+int Utils::to_int_or(const std::string &str, int default_value) {
+  if (str.empty()) return default_value;
+  try {
+    size_t pos = 0;
+    int val = std::stoi(str, &pos);
+    while (pos < str.size() && std::isspace(static_cast<unsigned char>(str[pos]))) pos++;
+    return (pos == str.size()) ? val : default_value;
+  } catch (const std::exception &) {
+    return default_value;
+  }
+}
+
+double Utils::option_to_double_or(const OPTION_VALUE_T &options, const char *key, double default_value) {
+  auto it = options.find(key);
+  if (it == options.end() || it->second.empty()) return default_value;
+  return Utils::to_double_or(it->second[0], default_value);
+}
+
+int Utils::option_to_int_or(const OPTION_VALUE_T &options, const char *key, int default_value) {
+  auto it = options.find(key);
+  if (it == options.end() || it->second.empty()) return default_value;
+  return Utils::to_int_or(it->second[0], default_value);
+}
+
 int Utils::update_model_in_catalog(TABLE *table, const std::string &model_handle, size_t field_no,
                                    const std::string &field_value) {
   THD *thd = current_thd;
@@ -841,38 +907,82 @@ int Utils::read_model_content(std::string &model_handle_name, Json_wrapper &opti
   // get the model content from model catalog table by model handle name. table
   my_bitmap_map *old_map = tmp_use_all_columns(cat_table_ptr, cat_table_ptr->read_set);
   if (cat_table_ptr->file->ha_external_lock(current_thd, F_RDLCK)) {
+    if (old_map) tmp_restore_column_map(cat_table_ptr->read_set, old_map);
     Utils::close_table(cat_table_ptr);
     return HA_ERR_GENERIC;
   }
 
   if (cat_table_ptr->file->inited == handler::NONE && cat_table_ptr->file->ha_rnd_init(true)) {
+    if (old_map) tmp_restore_column_map(cat_table_ptr->read_set, old_map);
     cat_table_ptr->file->ha_external_lock(current_thd, F_UNLCK);
     Utils::close_table(cat_table_ptr);
     return HA_ERR_GENERIC;
   }
 
-  while (cat_table_ptr->file->ha_rnd_next(cat_table_ptr->record[0]) != HA_ERR_END_OF_FILE) {
+  int scan_err = 0;
+  bool row_found = false, meta_read = false;
+  for (;;) {
+    // Only END_OF_FILE ends the scan cleanly. Testing for it alone would spin
+    // forever on any other error, so stop on those too (a deleted record is
+    // simply skipped).
+    int rc = cat_table_ptr->file->ha_rnd_next(cat_table_ptr->record[0]);
+    if (rc == HA_ERR_END_OF_FILE) break;
+    if (rc == HA_ERR_RECORD_DELETED) continue;
+    if (rc != 0) {
+      scan_err = rc;
+      break;
+    }
     // handle_name.
-    String handle_name, model_content;
+    String handle_name;
     auto field_ptr = *(cat_table_ptr->field + static_cast<int>(MODEL_CATALOG_FIELD_INDEX::MODEL_HANDLE));
+    if (field_ptr->is_null()) continue;
     handle_name.set_charset(field_ptr->charset());
-    field_ptr->val_str(&handle_name);
+    String *handle = field_ptr->val_str(&handle_name);
+    if (!handle) continue;
 
-    if (likely(strcmp(handle_name.c_ptr_safe(), model_handle_name.c_str())))  // not this one.
+    if (likely(handle->length() != model_handle_name.size() ||
+               memcmp(handle->ptr(), model_handle_name.c_str(), handle->length())))  // not this one.
       continue;
     else {
+      row_found = true;
       // model object.[trainned model content]
       field_ptr = *(cat_table_ptr->field + static_cast<int>(MODEL_CATALOG_FIELD_INDEX::MODEL_METADATA));
       assert(field_ptr->type() == MYSQL_TYPE_JSON);
-      down_cast<Field_json *>(field_ptr)->val_json(&options);
+      Json_wrapper row_wrapper;
+      if (!field_ptr->is_null() && !down_cast<Field_json *>(field_ptr)->val_json(&row_wrapper)) {
+        // val_json() hands back a wrapper over the binary JSON still sitting in
+        // this table's record buffer. close_table() below frees that buffer, so
+        // handing the wrapper straight to the caller leaves it reading freed
+        // memory -- whether that still looks like valid JSON depends on the heap.
+        // Take an owning copy while the row is alive.
+        Json_dom_ptr meta_dom = row_wrapper.clone_dom();
+        if (meta_dom) {
+          options = Json_wrapper(std::move(meta_dom));
+          meta_read = true;
+        }
+      }
       break;
     }
-  }  // while
+  }  // for
 
   if (old_map) tmp_restore_column_map(cat_table_ptr->read_set, old_map);
   cat_table_ptr->file->ha_rnd_end();
   cat_table_ptr->file->ha_external_lock(current_thd, F_UNLCK);
   Utils::close_table(cat_table_ptr);
+
+  if (scan_err) return HA_ERR_GENERIC;
+  if (!meta_read) {
+    // Returning 0 here would leave `options` untouched and let the caller carry
+    // on as if the model existed. Only describe the failure when nothing else
+    // has: an error already in flight (ER_NEED_REPREPARE, say) must survive.
+    if (!current_thd->is_error()) {
+      std::ostringstream err;
+      err << model_handle_name
+          << (row_found ? " has no metadata in the model catalog" : " does not exist in the model catalog");
+      my_error(ER_ML_FAIL, MYF(0), err.str().c_str());
+    }
+    return HA_ERR_GENERIC;
+  }
   return 0;
 }
 
@@ -905,9 +1015,21 @@ int Utils::read_model_object_content(std::string &model_handle_name, std::string
   };
   std::vector<Chunk> chunks;
 
-  while (cat_table_ptr->file->ha_rnd_next(cat_table_ptr->record[0]) != HA_ERR_END_OF_FILE) {
+  int scan_err = 0;
+  for (;;) {
+    // Only END_OF_FILE ends the scan cleanly; any other error must break out
+    // rather than spin (a deleted record is simply skipped).
+    int rc = cat_table_ptr->file->ha_rnd_next(cat_table_ptr->record[0]);
+    if (rc == HA_ERR_END_OF_FILE) break;
+    if (rc == HA_ERR_RECORD_DELETED) continue;
+    if (rc != 0) {
+      scan_err = rc;
+      break;
+    }
+
     String handle_buf;
     Field *handle_field = cat_table_ptr->field[static_cast<int>(MODEL_OBJECT_CATALOG_FIELD_INDEX::MODEL_HANDLE)];
+    if (handle_field->is_null()) continue;
     String *handle = handle_field->val_str(&handle_buf);
 
     if (handle && handle->length() == model_handle_name.size() &&
@@ -916,8 +1038,10 @@ int Utils::read_model_object_content(std::string &model_handle_name, std::string
       uint32_t chunk_id = static_cast<uint32_t>(chunk_id_field->val_int());
 
       Field *model_obj_field = cat_table_ptr->field[static_cast<int>(MODEL_OBJECT_CATALOG_FIELD_INDEX::MODEL_OBJECT)];
+      if (model_obj_field->is_null()) continue;
       String model_obj_buf;
       String *model_obj = model_obj_field->val_str(&model_obj_buf);
+      if (!model_obj) continue;
       // val_str() may return a pointer that aliases the row buffer, which the
       // next ha_rnd_next() overwrites; deep-copy the bytes now.
       chunks.push_back({chunk_id, std::string(model_obj->ptr(), model_obj->length())});
@@ -935,6 +1059,18 @@ int Utils::read_model_object_content(std::string &model_handle_name, std::string
   cat_table_ptr->file->ha_rnd_end();
   cat_table_ptr->file->ha_external_lock(current_thd, F_UNLCK);
   Utils::close_table(cat_table_ptr);
+
+  if (scan_err) return HA_ERR_GENERIC;
+  if (chunks.empty()) {
+    // No chunks means the handle has no model object at all; returning 0 would
+    // hand the caller an empty model to load.
+    if (!current_thd->is_error()) {
+      std::ostringstream err;
+      err << model_handle_name << " has no model object in the model catalog";
+      my_error(ER_ML_FAIL, MYF(0), err.str().c_str());
+    }
+    return HA_ERR_GENERIC;
+  }
   return 0;
 }
 
@@ -1074,17 +1210,15 @@ int Utils::model_predict(int type, std::string &model_handle_name, size_t n_samp
   assert(type == C_API_PREDICT_NORMAL || type == C_API_PREDICT_RAW_SCORE || type == C_API_PREDICT_LEAF_INDEX ||
          type == C_API_PREDICT_CONTRIB);
   std::string score_params;
-  BoosterHandle handler{nullptr};
-  {
-    std::lock_guard<std::mutex> lock(models_mutex);
-    handler = Utils::load_trained_model_from_string(Loaded_models[model_handle_name]);
+  std::string model_content;
+  if (Utils::get_loaded_model_content(model_handle_name, model_content)) return HA_ERR_GENERIC;
 
-    if (!handler) {
-      std::ostringstream err;
-      err << model_handle_name << " can not load model from content string";
-      my_error(ER_ML_FAIL, MYF(0), err.str().c_str());
-      return HA_ERR_GENERIC;
-    }
+  BoosterHandle handler = Utils::load_trained_model_from_string(model_content);
+  if (!handler) {
+    std::ostringstream err;
+    err << model_handle_name << " can not load model from content string";
+    my_error(ER_ML_FAIL, MYF(0), err.str().c_str());
+    return HA_ERR_GENERIC;
   }
 
   assert(sizeof(double) == 8);
@@ -1145,11 +1279,7 @@ int Utils::ML_predict_row(int type, std::string &model_handle_name,
          type == C_API_PREDICT_LEAF_INDEX || type == C_API_PREDICT_CONTRIB);
 
   std::string model_content;
-  {
-    std::lock_guard<std::mutex> lock(models_mutex);
-    model_content = Loaded_models[model_handle_name];
-    assert(model_content.length());
-  }
+  if (Utils::get_loaded_model_content(model_handle_name, model_content)) return HA_ERR_GENERIC;
 
   auto booster = Utils::load_trained_model_from_string(model_content);
   if (!booster) return HA_ERR_GENERIC;
@@ -1169,11 +1299,7 @@ int Utils::ML_predict_row(int type, std::string &model_handle_name,
       // std::stod throws on it. Nothing up the stack catches that, so letting
       // it escape aborts the server. read_data() feeds a NULL numeric to
       // training as 0.0, so fall back to the same value here.
-      try {
-        value = std::stod(field.second);
-      } catch (const std::exception &) {
-        value = 0.0;
-      }
+      value = Utils::to_double_or(field.second, 0.0);
     } else {
       // Text field, to find mapping value.
       auto txt2num = txt2numeric_dict[field.first];

--- a/ml/ml_utils.h
+++ b/ml/ml_utils.h
@@ -150,6 +150,35 @@ class Utils {
    */
   static BoosterHandle load_trained_model_from_string(std::string &model_content);
 
+  /**
+   * fetch the content of a model that is currently loaded into Rapid.
+   * Never index Loaded_models directly: operator[] inserts an empty entry for a
+   * handle that was never loaded, and precheck_and_process_meta_info() then
+   * reports that handle as already loaded forever after.
+   * @param[in] model_handle_name, the handle name of the loaded model.
+   * @param[out] model_content, the serialized model.
+   * @retval 0 success.
+   * @retval error code the handle is not loaded (an error is raised).
+   */
+  static int get_loaded_model_content(const std::string &model_handle_name, std::string &model_content);
+
+  /**
+   * parse an option value that must be a number. Option values come straight
+   * from user JSON, so a non-numeric one must not escape as an exception.
+   * @param[in] str, the raw option value.
+   * @param[in] default_value, returned when str is empty or not a number.
+   * @return the parsed value, or default_value.
+   */
+  static double to_double_or(const std::string &str, double default_value);
+  static int to_int_or(const std::string &str, int default_value);
+
+  /**
+   * look an option up and parse it as a number, falling back to default_value
+   * when the key is absent, its value list is empty, or the value is not numeric.
+   */
+  static double option_to_double_or(const OPTION_VALUE_T &options, const char *key, double default_value);
+  static int option_to_int_or(const OPTION_VALUE_T &options, const char *key, int default_value);
+
   static int update_model_in_catalog(TABLE *table, const std::string &model_handle, size_t field_no,
                                      const std::string &field_value);
   /**

--- a/mysql-test/suite/ml/r/ml_score_metrics.result
+++ b/mysql-test/suite/ml/r/ml_score_metrics.result
@@ -1,0 +1,74 @@
+DROP DATABASE IF EXISTS ML_SCHEMA_root;
+DROP DATABASE IF EXISTS shannon_ml_metrics;
+CREATE DATABASE shannon_ml_metrics;
+ALTER DATABASE shannon_ml_metrics CHARACTER SET ascii COLLATE ascii_bin;
+USE shannon_ml_metrics;
+CREATE TABLE b_train (f1 INT, f2 INT, f3 DOUBLE, label INT);
+SET @bin_model = 'metrics_binary';
+CALL sys.ML_TRAIN('shannon_ml_metrics.b_train', 'label',
+JSON_OBJECT('task', 'classification', 'exclude_column_list', JSON_ARRAY('id')), @bin_model);
+CALL sys.ML_MODEL_LOAD(@bin_model, NULL);
+CALL sys.ML_SCORE('shannon_ml_metrics.b_test', 'label', @bin_model, 'accuracy', @acc, null);
+SELECT @acc >= 0.99 AS binary_accuracy_ok;
+binary_accuracy_ok
+1
+CALL sys.ML_SCORE('shannon_ml_metrics.b_test', 'label', @bin_model, 'roc_auc', @auc, null);
+SELECT @auc >= 0.99 AS binary_roc_auc_ok;
+binary_roc_auc_ok
+1
+CALL sys.ML_SCORE('shannon_ml_metrics.b_test', 'label', @bin_model, 'f1', @f1, null);
+CALL sys.ML_SCORE('shannon_ml_metrics.b_test', 'label', @bin_model, 'precision', @prec, null);
+CALL sys.ML_SCORE('shannon_ml_metrics.b_test', 'label', @bin_model, 'recall', @recall, null);
+SELECT @f1 >= 0.99 AND @prec >= 0.99 AND @recall >= 0.99 AS binary_prf_ok;
+binary_prf_ok
+1
+CALL sys.ML_SCORE('shannon_ml_metrics.b_test', 'label', @bin_model, 'neg_log_loss', @logloss, null);
+SELECT @logloss <= 0 AS binary_neg_log_loss_ok;
+binary_neg_log_loss_ok
+1
+CALL sys.ML_MODEL_UNLOAD(@bin_model);
+CREATE TABLE m_train (f1 INT, f2 INT, label INT);
+SET @multi_model = 'metrics_multiclass';
+CALL sys.ML_TRAIN('shannon_ml_metrics.m_train', 'label',
+JSON_OBJECT('task', 'classification', 'exclude_column_list', JSON_ARRAY('id')), @multi_model);
+CALL sys.ML_MODEL_LOAD(@multi_model, NULL);
+CALL sys.ML_SCORE('shannon_ml_metrics.m_test', 'label', @multi_model, 'accuracy', @m_acc, null);
+SELECT @m_acc >= 0.99 AS multi_accuracy_ok;
+multi_accuracy_ok
+1
+CALL sys.ML_SCORE('shannon_ml_metrics.m_test', 'label', @multi_model, 'f1_macro', @m_f1_macro, null);
+CALL sys.ML_SCORE('shannon_ml_metrics.m_test', 'label', @multi_model, 'f1_micro', @m_f1_micro, null);
+CALL sys.ML_SCORE('shannon_ml_metrics.m_test', 'label', @multi_model, 'f1_weigthed', @m_f1_weighted, null);
+SELECT @m_f1_macro >= 0.99 AND @m_f1_micro >= 0.99 AND @m_f1_weighted >= 0.99 AS multi_f1_averaging_ok;
+multi_f1_averaging_ok
+1
+CALL sys.ML_SCORE('shannon_ml_metrics.m_test', 'label', @multi_model, 'precision_macro', @m_prec_macro, null);
+CALL sys.ML_SCORE('shannon_ml_metrics.m_test', 'label', @multi_model, 'precision_micro', @m_prec_micro, null);
+CALL sys.ML_SCORE('shannon_ml_metrics.m_test', 'label', @multi_model, 'recall_macro', @m_recall_macro, null);
+CALL sys.ML_SCORE('shannon_ml_metrics.m_test', 'label', @multi_model, 'recall_weighted', @m_recall_weighted, null);
+SELECT @m_prec_macro >= 0.99 AND @m_prec_micro >= 0.99 AS multi_precision_averaging_ok;
+multi_precision_averaging_ok
+1
+SELECT @m_recall_macro >= 0.99 AND @m_recall_weighted >= 0.99 AS multi_recall_averaging_ok;
+multi_recall_averaging_ok
+1
+SELECT @m_f1_micro = @m_acc AS multi_micro_f1_equals_accuracy;
+multi_micro_f1_equals_accuracy
+1
+CALL sys.ML_SCORE('shannon_ml_metrics.m_test', 'label', @multi_model, 'roc_auc', @m_auc, null);
+ERROR HY000: ML operation failed. roc_auc is only supported for binary classification.
+CALL sys.ML_SCORE('shannon_ml_metrics.m_test', 'label', @multi_model, 'neg_log_loss', @m_logloss, null);
+ERROR HY000: ML operation failed. neg_log_loss is only supported for binary classification.
+CALL sys.ML_MODEL_UNLOAD(@multi_model);
+SET @bad_model = 'metrics_bad_task';
+CALL sys.ML_TRAIN('shannon_ml_metrics.b_train', 'label', JSON_OBJECT('task', 'not_a_task'), @bad_model);
+ERROR HY000: ML operation failed. unsupported ML task: NOT_A_TASK.
+SELECT COUNT(*) AS bad_task_not_trained FROM ML_SCHEMA_root.MODEL_CATALOG WHERE MODEL_HANDLE = 'metrics_bad_task';
+bad_task_not_trained
+0
+DROP DATABASE IF EXISTS ML_SCHEMA_root;
+ALTER TABLE b_train SECONDARY_UNLOAD;
+ALTER TABLE b_test SECONDARY_UNLOAD;
+ALTER TABLE m_train SECONDARY_UNLOAD;
+ALTER TABLE m_test SECONDARY_UNLOAD;
+DROP DATABASE IF EXISTS shannon_ml_metrics;

--- a/mysql-test/suite/ml/t/ml_score_metrics.test
+++ b/mysql-test/suite/ml/t/ml_score_metrics.test
@@ -1,0 +1,152 @@
+##############################################################################
+# ShannonBase test case for ML_SCORE metric semantics.
+# ShannonBase copyright 2023-
+#
+# The macro/micro/weighted/samples variants of f1, precision and recall used to
+# fall through to a single binary calculation, and roc_auc returned plain
+# accuracy. This test pins the averaging semantics and the metrics that a
+# multiclass model cannot support.
+##############################################################################
+--disable_query_log
+# LightGBM prints these while growing trees on small, cleanly separable data.
+CALL mtr.add_suppression("\\[LightGBM\\] \\[Warning\\] No further splits with positive gain");
+CALL mtr.add_suppression("\\[LightGBM\\] \\[Warning\\] There are no meaningful features");
+CALL mtr.add_suppression("\\[LightGBM\\] \\[Warning\\] Stopped training because there are no more leaves");
+--enable_query_log
+
+--disable_warnings
+DROP DATABASE IF EXISTS ML_SCHEMA_root;
+DROP DATABASE IF EXISTS shannon_ml_metrics;
+CREATE DATABASE shannon_ml_metrics;
+ALTER DATABASE shannon_ml_metrics CHARACTER SET ascii COLLATE ascii_bin;
+USE shannon_ml_metrics;
+--enable_warnings
+
+--disable_query_log
+# A 0..99 generator, so every class carries enough rows for the booster to
+# split; a handful of rows per class trains a constant model and every metric
+# then degenerates to the same number.
+CREATE TABLE seq10 (n INT);
+INSERT INTO seq10 VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+--enable_query_log
+
+##############################################################################
+# Binary classification, cleanly separable.
+##############################################################################
+CREATE TABLE b_train (f1 INT, f2 INT, f3 DOUBLE, label INT);
+
+--disable_query_log
+INSERT INTO b_train (f1,f2,f3,label)
+SELECT a.n*10+b.n, a.n*10+b.n+5, (a.n*10+b.n)/100, 0 FROM seq10 a, seq10 b;
+INSERT INTO b_train (f1,f2,f3,label)
+SELECT 1000+a.n*10+b.n, 1000+a.n*10+b.n+5, (1000+a.n*10+b.n)/100, 1 FROM seq10 a, seq10 b;
+
+CREATE TABLE b_test LIKE b_train;
+INSERT INTO b_test SELECT * FROM b_train;
+
+ALTER TABLE b_train ADD COLUMN id INT AUTO_INCREMENT NOT SECONDARY PRIMARY KEY FIRST;
+ALTER TABLE b_test ADD COLUMN id INT AUTO_INCREMENT NOT SECONDARY PRIMARY KEY FIRST;
+ALTER TABLE b_train SECONDARY_ENGINE = RAPID;
+ALTER TABLE b_test SECONDARY_ENGINE = RAPID;
+ALTER TABLE b_train SECONDARY_LOAD;
+ALTER TABLE b_test SECONDARY_LOAD;
+--enable_query_log
+
+SET @bin_model = 'metrics_binary';
+CALL sys.ML_TRAIN('shannon_ml_metrics.b_train', 'label',
+                  JSON_OBJECT('task', 'classification', 'exclude_column_list', JSON_ARRAY('id')), @bin_model);
+CALL sys.ML_MODEL_LOAD(@bin_model, NULL);
+
+CALL sys.ML_SCORE('shannon_ml_metrics.b_test', 'label', @bin_model, 'accuracy', @acc, null);
+SELECT @acc >= 0.99 AS binary_accuracy_ok;
+
+# roc_auc is a real AUC now, not a copy of accuracy.
+CALL sys.ML_SCORE('shannon_ml_metrics.b_test', 'label', @bin_model, 'roc_auc', @auc, null);
+SELECT @auc >= 0.99 AS binary_roc_auc_ok;
+
+# Plain f1/precision/recall keep average='binary' on a two-class problem.
+CALL sys.ML_SCORE('shannon_ml_metrics.b_test', 'label', @bin_model, 'f1', @f1, null);
+CALL sys.ML_SCORE('shannon_ml_metrics.b_test', 'label', @bin_model, 'precision', @prec, null);
+CALL sys.ML_SCORE('shannon_ml_metrics.b_test', 'label', @bin_model, 'recall', @recall, null);
+SELECT @f1 >= 0.99 AND @prec >= 0.99 AND @recall >= 0.99 AS binary_prf_ok;
+
+# neg_log_loss is negated, so it must never be positive.
+CALL sys.ML_SCORE('shannon_ml_metrics.b_test', 'label', @bin_model, 'neg_log_loss', @logloss, null);
+SELECT @logloss <= 0 AS binary_neg_log_loss_ok;
+
+CALL sys.ML_MODEL_UNLOAD(@bin_model);
+
+##############################################################################
+# Multiclass classification, three equally sized separable classes.
+##############################################################################
+CREATE TABLE m_train (f1 INT, f2 INT, label INT);
+
+--disable_query_log
+INSERT INTO m_train (f1,f2,label)
+SELECT a.n*10+b.n, a.n*10+b.n+3, 0 FROM seq10 a, seq10 b;
+INSERT INTO m_train (f1,f2,label)
+SELECT 1000+a.n*10+b.n, 1000+a.n*10+b.n+3, 1 FROM seq10 a, seq10 b;
+INSERT INTO m_train (f1,f2,label)
+SELECT 2000+a.n*10+b.n, 2000+a.n*10+b.n+3, 2 FROM seq10 a, seq10 b;
+
+CREATE TABLE m_test LIKE m_train;
+INSERT INTO m_test SELECT * FROM m_train;
+
+ALTER TABLE m_train ADD COLUMN id INT AUTO_INCREMENT NOT SECONDARY PRIMARY KEY FIRST;
+ALTER TABLE m_test ADD COLUMN id INT AUTO_INCREMENT NOT SECONDARY PRIMARY KEY FIRST;
+ALTER TABLE m_train SECONDARY_ENGINE = RAPID;
+ALTER TABLE m_test SECONDARY_ENGINE = RAPID;
+ALTER TABLE m_train SECONDARY_LOAD;
+ALTER TABLE m_test SECONDARY_LOAD;
+--enable_query_log
+
+SET @multi_model = 'metrics_multiclass';
+CALL sys.ML_TRAIN('shannon_ml_metrics.m_train', 'label',
+                  JSON_OBJECT('task', 'classification', 'exclude_column_list', JSON_ARRAY('id')), @multi_model);
+CALL sys.ML_MODEL_LOAD(@multi_model, NULL);
+
+CALL sys.ML_SCORE('shannon_ml_metrics.m_test', 'label', @multi_model, 'accuracy', @m_acc, null);
+SELECT @m_acc >= 0.99 AS multi_accuracy_ok;
+
+# Every averaged variant is one-vs-rest over all three classes. The old binary
+# calculation counted class 2 as a false negative of class 1, which capped
+# recall at 0.5 and f1 at 2/3 on this data, so these bounds fail unless the
+# averaging is really being applied.
+CALL sys.ML_SCORE('shannon_ml_metrics.m_test', 'label', @multi_model, 'f1_macro', @m_f1_macro, null);
+CALL sys.ML_SCORE('shannon_ml_metrics.m_test', 'label', @multi_model, 'f1_micro', @m_f1_micro, null);
+CALL sys.ML_SCORE('shannon_ml_metrics.m_test', 'label', @multi_model, 'f1_weigthed', @m_f1_weighted, null);
+SELECT @m_f1_macro >= 0.99 AND @m_f1_micro >= 0.99 AND @m_f1_weighted >= 0.99 AS multi_f1_averaging_ok;
+
+CALL sys.ML_SCORE('shannon_ml_metrics.m_test', 'label', @multi_model, 'precision_macro', @m_prec_macro, null);
+CALL sys.ML_SCORE('shannon_ml_metrics.m_test', 'label', @multi_model, 'precision_micro', @m_prec_micro, null);
+CALL sys.ML_SCORE('shannon_ml_metrics.m_test', 'label', @multi_model, 'recall_macro', @m_recall_macro, null);
+CALL sys.ML_SCORE('shannon_ml_metrics.m_test', 'label', @multi_model, 'recall_weighted', @m_recall_weighted, null);
+SELECT @m_prec_macro >= 0.99 AND @m_prec_micro >= 0.99 AS multi_precision_averaging_ok;
+SELECT @m_recall_macro >= 0.99 AND @m_recall_weighted >= 0.99 AS multi_recall_averaging_ok;
+
+# Micro-averaged f1 on a single-label problem is exactly accuracy.
+SELECT @m_f1_micro = @m_acc AS multi_micro_f1_equals_accuracy;
+
+# Both of these need a score rather than a label, which model_predict() only
+# hands back for a binary model.
+--error ER_ML_FAIL
+CALL sys.ML_SCORE('shannon_ml_metrics.m_test', 'label', @multi_model, 'roc_auc', @m_auc, null);
+--error ER_ML_FAIL
+CALL sys.ML_SCORE('shannon_ml_metrics.m_test', 'label', @multi_model, 'neg_log_loss', @m_logloss, null);
+
+CALL sys.ML_MODEL_UNLOAD(@multi_model);
+
+##############################################################################
+# An unrecognized task is rejected rather than silently training a classifier.
+##############################################################################
+SET @bad_model = 'metrics_bad_task';
+--error ER_ML_FAIL
+CALL sys.ML_TRAIN('shannon_ml_metrics.b_train', 'label', JSON_OBJECT('task', 'not_a_task'), @bad_model);
+SELECT COUNT(*) AS bad_task_not_trained FROM ML_SCHEMA_root.MODEL_CATALOG WHERE MODEL_HANDLE = 'metrics_bad_task';
+
+DROP DATABASE IF EXISTS ML_SCHEMA_root;
+ALTER TABLE b_train SECONDARY_UNLOAD;
+ALTER TABLE b_test SECONDARY_UNLOAD;
+ALTER TABLE m_train SECONDARY_UNLOAD;
+ALTER TABLE m_test SECONDARY_UNLOAD;
+DROP DATABASE IF EXISTS shannon_ml_metrics;


### PR DESCRIPTION
Scoring metrics returned wrong values. The macro/micro/weighted/samples variants of f1, precision and recall all fell through to the same binary calculation, and roc_auc returned plain accuracy. Replace the binary-only helper with calc_prf_metric(), which implements sklearn's binary, macro, micro and weighted averaging, and add a real AUC via the Mann-Whitney U identity with tie-averaged ranks. roc_auc and neg_log_loss need a score rather than a label, so reject them for multiclass models instead of scoring the arg-max class index.

Partial dependence sized its prediction buffer at n_sample while a multiclass booster writes n_sample * num_classes doubles, so LGBM_BoosterPredictForMat wrote past the end of the vector.

Several process-wide maps were indexed with operator[]. OPT_TASKS_MAP inserted a node value-initialized to CLASSIFICATION for an unrecognized task -- unlocked, and so a typo silently trained a classifier -- and Loaded_models inserted an empty entry for a handle that was never loaded, after which that handle reported itself as loaded forever. Look both up instead, and raise ER_ML_FAIL on the unknown-task path, which previously failed the statement with no error set.

Option values come straight from user JSON, where std::stod throws on anything non-numeric and nothing up the stack catches it. Route those parses through new to_double_or()/to_int_or() helpers.

Both model-catalog scans tested only for HA_ERR_END_OF_FILE, so any other handler error spun forever; they now stop on real errors and skip deleted records. read_model_content() also handed back a Json_wrapper over the record buffer that close_table() then frees, and both scans returned 0 when the handle was absent, letting the caller carry on with an empty model. Take an owning copy and report the miss, without clobbering an in-flight error such as ER_NEED_REPREPARE.

validate_table_size() gated the row-count check on HA_STATS_RECORDS_IS_EXACT, which InnoDB never sets, so the 100M-row limit never applied to the tables it exists to protect; it also summed max_data_file_length, the largest file the engine would allow rather than a size in use.

I hereby agree to the terms of the CLA available at: http://www.shannondata.ai/doc/cla/

## Summary

_Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR._

- Fixes #[Link the issue here]

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):